### PR TITLE
Surefire plugin version isn't set

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,3 @@
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.crsh</groupId>
@@ -609,6 +608,7 @@
 
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.12</version>
           <executions>
             <execution>
               <id>default-test</id>


### PR DESCRIPTION
Surefire plugin version isn't set and uses the one defined by maven (2.10 from mvn 3.0.3)

In that case CRasSH core tests are failing with a strange error :
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.7.2:test (default-test) on project crsh.shell.core: Error while executing forked tests.; nested exception is java.lang.IllegalStateException: testSetStarting called twice -> [Help 1]
Upgrading to 1.12 gives a better error :
Failed tests:   testCancel(org.crsh.shell.impl.async.ShutdownTestCase): expected:<CANCELED> but was:<TERMINATED>
