### PR TITLE
- make PropertyDescription compliant with HashMap contract

### DIFF
--- a/shell/core/src/main/java/org/crsh/plugin/PropertyDescriptor.java
+++ b/shell/core/src/main/java/org/crsh/plugin/PropertyDescriptor.java
@@ -165,4 +165,32 @@ public abstract class PropertyDescriptor<T> {
   public final String toString() {
     return "PropertyDescriptor[name=" + name + ",type=" + type.getName() + ",description=" + description + "]";
   }
+
+  @Override
+  public int hashCode() {
+	  final int prime = 31;
+	  int result = 1;
+	  result = prime * result + ((name == null) ? 0 : name.hashCode());
+	  return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+	  if (this == obj)
+		  return true;
+	  if (obj == null)
+		  return false;
+	  if (!(obj instanceof PropertyDescriptor))
+		  return false;
+	  PropertyDescriptor other = (PropertyDescriptor) obj;
+	  if (name == null) {
+		  if (other.name != null)
+			  return false;
+	  } else if (!name.equals(other.name))
+		  return false;
+	  return true;
+  }
+
+  
+  
 }


### PR DESCRIPTION
PropertyDescription should implements hashcode/equals because we put it into an hashmap.
