### PR TITLE
Display the prompt message before waiting for input

### DIFF
--- a/shell/core/src/main/java/org/crsh/processor/term/ProcessContext.java
+++ b/shell/core/src/main/java/org/crsh/processor/term/ProcessContext.java
@@ -70,6 +70,7 @@ class ProcessContext implements ShellProcessContext, Runnable {
   public String readLine(String msg, boolean echo) {
     try {
       processor.term.provide(Text.create(msg));
+      processor.term.flush();
     }
     catch (IOException e) {
       return null;


### PR DESCRIPTION
The prompt message was not displayed before waiting for the input. For example we had the problem with the JCR "ws login" command. The "ws login" command only displayed a blank line and waited for the password. The "password:" message was only displayed once the password has been entered.
