### PR TITLE
documentation fixes

### DIFF
--- a/doc/cookbook/src/main/asciidoc/book.asciidoc
+++ b/doc/cookbook/src/main/asciidoc/book.asciidoc
@@ -1,6 +1,5 @@
-CRaSH reference guide
-=====================
-Julien Viet <julien@julienviet.com>
+= CRaSH Cookbook
+Julien Viet <http://www.julienviet.com>
 
 The Common Reusable SHell (CRaSH) deploys in a Java runtime and provides interactions with the JVM.
 Commands are written in Groovy and can be developped at runtime making the extension of the shell very easy

--- a/doc/cookbook/src/main/asciidoc/faq.asciidoc
+++ b/doc/cookbook/src/main/asciidoc/faq.asciidoc
@@ -11,7 +11,7 @@ Moreover, you could add your command (Java/Groovy) and that's why CRaSH is reall
 * Make command for your application (add data in a cache, add user, monitor jobs ).
 * Make your JMX command.
 
-=== What is the differences between CRaSH and JMX ?
+=== What are the differences between CRaSH and JMX ?
 
 JMX provides only bean and methods, that's all. CRaSH permit to access to JMX and to make command with it.
 CRaSH also permit to make script with thread, jdbc, entity ...
@@ -20,18 +20,18 @@ CRaSH also permit to make script with thread, jdbc, entity ...
 
 === How can I run CRaSH ?
 
-See documentation : [[reference.html#running]]
+Refer to documentation in the <<reference#running_crash,Running Crash>> chapter.
 
 === How can I connect Crash to a JVM ?
 
-See documentation Connection in Shell Usage chapter  [[reference.html#connection]]
+Refer to documentation in the <<reference#connection,Connection>> section of the Shell Usage chapter.
 
 == Basic
 
 === What is the best way to create a command ?
 
 The best way to create a command is to use CRaSH utilities.
-See command as a class : [[reference.html#command_as_class]]
+Refer to documentation in the <<reference#commands_as_class,Commands as a class>> section of the Developers chapter.
 
 === What is the best way to start with CRaSH ?
 

--- a/doc/cookbook/src/main/asciidoc/first_command.asciidoc
+++ b/doc/cookbook/src/main/asciidoc/first_command.asciidoc
@@ -1,4 +1,3 @@
-
 In this cookbook, you will learn how to create a simple script command. You will see that
 you can create it dynamically without restarting CRaSH.
 

--- a/doc/cookbook/src/main/asciidoc/how_to_database.asciidoc
+++ b/doc/cookbook/src/main/asciidoc/how_to_database.asciidoc
@@ -1,13 +1,16 @@
-
 In this cookbook, you will see how to connect to a database and how to execute query.
 
 == Connect to a database
 
 You have 2 possibility to connect to your databases :
-* open    :  open a connection from JNDI bound datasource
-* connect :  connect to database with a JDBC connection string
 
-Here is some examples :
+open ::
+  open a connection from JNDI bound datasource
+
+connect ::
+  connect to database with a JDBC connection string
+
+Here are some examples:
 
 === H2
 
@@ -34,5 +37,4 @@ NOTE: Table name are case sensitive.
 ----
 jdbc close
 ----
-
 

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -70,18 +70,22 @@
                 <goal>process-asciidoc</goal>
               </goals>
               <configuration>
-                <!-- asciidoctor -d book -o target/book.html -a toc2 -a copycss -a source-highlighter=highlightjs target/asciidoc/book.asciidoc -->
+                <!-- asciidoctor -d book -o target/book.html -a copycss -a toc2 -a sectanchors \
+                     -a source-highlighter=coderay -a stylesheet=foundation-lime.css -a crash-version=${project.version} \
+                     target/asciidoc/book.asciidoc -->
                 <sourceDirectory>${project.build.directory}/asciidoc</sourceDirectory>
                 <sourceDocumentName>${project.build.directory}/asciidoc/book.asciidoc</sourceDocumentName>
                 <outputDirectory>target/docs/html</outputDirectory>
-                <compact>true</compact>
                 <backend>html</backend>
                 <doctype>book</doctype>
                 <attributes>
-                  <toc2 />
+                  <toc2>1</toc2>
                   <stylesheet>foundation-lime.css</stylesheet>
-                  <source-highlighter>highlightjs</source-highlighter>
-                  <version>${project.version}</version>
+                  <source-highlighter>coderay</source-highlighter>
+                  <crash-version>${project.version}</crash-version>
+                  <sectanchors>1</sectanchors>
+                  <icons>font</icons>
+                  <sourcesdir>${project.build.directory}/sources</sourcesdir>
                 </attributes>
               </configuration>
             </execution>

--- a/doc/reference/src/main/asciidoc/book.asciidoc
+++ b/doc/reference/src/main/asciidoc/book.asciidoc
@@ -1,11 +1,11 @@
-CRaSH reference guide
-=====================
-Julien Viet <julien@julienviet.com>
+= CRaSH Reference Guide
+Julien Viet <http://www.julienviet.com>
 
 The Common Reusable SHell (CRaSH) deploys in a Java runtime and provides interactions with the JVM.
 Commands are written in Groovy and can be developped at runtime making the extension of the shell very easy
 with fast development cycle.
 
+[[running_crash]]
 = Running CRaSH
 
 include::running.asciidoc[]
@@ -36,8 +36,9 @@ include::jcr.asciidoc[]
 
 = Hey, I want to contribute!
 
-Drop me an email (see my @ on www.julienviet.com), any kind of help is welcome.
+Drop me an email. You can find my email on http://www.julienviet.com. Any kind of help is welcome.
 
+[appendix]
 = Commands reference
 
 include::reference.asciidoc[]

--- a/doc/reference/src/main/asciidoc/configuration.asciidoc
+++ b/doc/reference/src/main/asciidoc/configuration.asciidoc
@@ -50,8 +50,8 @@ crash.telnet.port=5000
 
 === Removing telnet or SSH access
 
-* to remove the telnet access, remove the jar file in the _WEB-INF/lib/crsh.connectors.telnet-{version}.jar_ .
-* to remove the SSH access, remove the jar file in the _WEB-INF/lib/crsh.connectors.ssh-{version}.jar_ .
+* to remove the telnet access, remove the jar file in the _WEB-INF/lib/crsh.connectors.telnet-{crash-version}.jar_.
+* to remove the SSH access, remove the jar file in the _WEB-INF/lib/crsh.connectors.ssh-{crash-version}.jar_.
 
 === Configuring shell default message
 

--- a/doc/reference/src/main/asciidoc/developers.asciidoc
+++ b/doc/reference/src/main/asciidoc/developers.asciidoc
@@ -1,6 +1,6 @@
 == Developping commands
 
-A CRaSH command is written in the http://groovy.codehaus.org/[Groovy] language. The Groovy language provides
+A CRaSH command is written in the http://groovy.codehaus.org[Groovy] language. The Groovy language provides
 several signifiant advantages:
 
 * Commands can be bare scripts or can be a class
@@ -8,7 +8,8 @@ several signifiant advantages:
 * Groovy is a dynamic language and can manipulate unknown types
 
 Each command has a corresponding Groovy file that contains a command class that will be invoked by the shell.
-The files are located in
+The files are located in:
+
 * _cmd_ directory for the standalone distribution
 * _/WEB-INF/crash/commands_ directory for the web archive deployment
 
@@ -18,29 +19,32 @@ command directory, which is useful to group commands of the same kind.
 In addition of that there are two special files called _login.groovy_ and _logout.groovy_ that are executed upon login
 and logout of a user. They are useful to setup and cleanup things related to the current user session.
 
+[[commands_as_script]]
 === Commands as a script
 
 The simplest command can be a simple script that returns a string
 
+[source,java]
 ----
 return "Hello World";
 ----
 
 The +out+ implicit variable can be used to send a message to the console:
 
+[source,java]
 ----
 out.println("Hello World");
 ----
 
 It can be even Groovier:
 
+[source,groovy]
 ----
 out << "Hello World"
 ----
 
+[[commands_as_class]]
 === Commands as a class
-
-[[command_as_class]]
 
 Class can also be used for defining a command, it provides significant advantages over scripts:
 
@@ -52,7 +56,7 @@ the command class.
 
 Let's study a simple class command example:
 
-[source,java]
+[source,groovy]
 ----
 import org.crsh.cli.Command;
 import org.crsh.cli.Usage;
@@ -99,7 +103,7 @@ usage: date [-h | --help] [-f | --format]
 A class can hold several commands allowing a single file to group several commands, let's study the JDBC command
 structure:
 
-[source,java]
+[source,groovy]
 ----
 @Usage("JDBC connection")
 class jdbc {
@@ -147,7 +151,7 @@ Let's review the various annotations for declaring a command.
 
 Defines a command method, when using a mono command the method should be named +main+:
 
-[source,java]
+[source,groovy]
 ----
 public class sample {
 
@@ -165,7 +169,7 @@ necessary anymore as the +@Command+ annotation is enough.
 
 Sub commands will simply declares several methods:
 
-[source,java]
+[source,groovy]
 ----
 public class sample {
 
@@ -187,7 +191,7 @@ Declares an option, the _names_ member must be specified: single letter name are
 other names are turned into GNU style option (double hyphen). Several names can specified as aliases of the same option. Option
 can be declared as method parameters or a class fields.
 
-[source,java]
+[source,groovy]
 ----
 public class sample {
 
@@ -213,7 +217,7 @@ public class sample {
 
 Declares an argument, this annotation should be declares as method parameters.
 
-[source,java]
+[source,groovy]
 ----
 public class sample {
 
@@ -233,7 +237,7 @@ public class sample {
 
 By default a parameter is optional, the +@Required+ annotation can be used to force the user to specify a parameter:
 
-[source,java]
+[source,groovy]
 ----
 public class sample {
 
@@ -248,7 +252,7 @@ public class sample {
 
 Those annotations are useful for documenting commands help and manual:
 
-[source,java]
+[source,groovy]
 ----
 @Usage("sample commands")
 public class sample {
@@ -286,7 +290,7 @@ CRaSH provides supports a few builtin simple types other than string:
 Boolean type is special because it does not need a value when combined with options. The option declaration is enough
 to set the value to true:
 
-[source,java]
+[source,groovy]
 ----
 public class sample {
 
@@ -316,7 +320,7 @@ package my;
 public class CustomValueType extends ValueType<Custom> {
 
   public CustomValueType() {
-    super(Custom.class); _ // <1>
+    super(Custom.class); // <1>
   }
 
   @Override
@@ -336,7 +340,7 @@ in the _/META-INF/services/_ directory of the jar containing the custom value ty
 
 .The custom value type declared in META-INF/services/org.crsh.cli.type.ValueType
 ----
-my.CustomValueTpye
+my.CustomValueType
 ----
 
 === Parameter multiplicity
@@ -391,31 +395,40 @@ public class mycommand {
 }
 ----
 
+[[command_context]]
 == Command context
 
-[[command_context]]
-
 During the execution of a command, CRaSH provides a _context_ for
-interacting with it : the property _context_ is resolved to an instance of +org.crsh.command.InvocationContext+,
-the invocation context class extends
-the +org.crsh.command.CommandContext+. Let's have a look at those types:
+interacting with it:
+
+* the property _context_ is resolved to an instance of +org.crsh.command.InvocationContext+
+* the invocation context class extends the +org.crsh.command.CommandContext+.
+
+Let's have a look at those types:
+
+////
+[source,java]
+.The command context
+----
+include::{sourcesdir}/org/crsh/command/CommandContext.java[tags=javadoc;classdef]
+----
+////
 
 [source,java]
 .The command context
 ----
-{@javadoc org.crsh.command.CommandContext}
-{@include org.crsh.command.CommandContext}
+include::{sourcesdir}/org/crsh/command/CommandContext.java[lines=26..-1]
 ----
 
 The +CommandContext+ provides access to the shell session as a +Map<String, Object>+. Session attributes
 can be accessed using this map, but they are also accessible as Groovy script properties. It means that writing such
 code will be equivalent:
 
-[source,java]
+[source,groovy]
 .Using shell session
 ----
 context.session["foo"] = "bar"; // <1>
-out.println(bar); // // <2>
+out.println(bar); // <2>
 ----
 <1> Bind the session attribute foo with the value bar
 <2> The bar is resolved as an session attribute by Groovy
@@ -430,7 +443,7 @@ are useful to interact with object shared globally by the CRaSH environment:
 * When attached to a virtual machine, the context attributes has only a single +instrumentation+ entry
  that is the +java.lang.instrument.Instrumentation+ instance obtained when attaching to a virtual machine.
 
-[source,java]
+[source,groovy]
 .Obtaining a Spring bean
 ----
 def bean = context.attributes.beans["TheBean"];
@@ -438,16 +451,23 @@ def bean = context.attributes.beans["TheBean"];
 
 Now let's examine the +InvocationContext+ that extends the +CommandContext+:
 
+////
 [source,java]
 .The invocation context
 ----
-{@javadoc org.crsh.command.InvocationContext}
-{@include org.crsh.command.InvocationContext}
+include::{sourcesdir}/org/crsh/command/InvocationContext.java[tags=javadoc;classdef]
+----
+////
+
+[source,java]
+.The invocation context
+----
+include::{sourcesdir}/org/crsh/command/InvocationContext.java[lines=26..-1]
 ----
 
 The +PrintWriter+ object is the command output, it can be used also via the _out_ property in Groovy scripts:
 
-[source,java]
+[source,groovy]
 .Printing on the shell
 ----
 context.writer.print("Hello"); // <1>
@@ -458,7 +478,7 @@ out.print("hello"); // <2>
 
 The +readLine+ method can be used to get interactive information from the user during the execution of a command.
 
-[source,java]
+[source,groovy]
 .Reading on the console
 ----
 def age = context.readLine("How old are you?", false);
@@ -472,17 +492,32 @@ the pipe mechanism.
 CRaSH adds (since version 1.1) the support for colored text and text decoration. Each portion of text printed
  has three style attributes:
 
-* _Decoration_ : bold, underline or blink, as the +org.crsh.text.Decoration+ enum.
+* _Decoration_: bold, underline or blink, as the +org.crsh.text.Decoration+ enum.
 * _Foreground_ color.
 * _Background_ color.
 
-Available colors are grouped as the +org.crsh.text.Color+ enum: black, red, green, yellow, blue, magenta, cyan, white.
+Available colors are grouped as the +org.crsh.text.Color+ enum:
+
+[cols="2*", frame="none", grid="none"]
+|===
+a|
+* [black]#black#
+* [red]#red#
+* [green]#green#
+* [yellow]#yellow#
+
+a|
+* [blue]#blue#
+* [fuchsia]#magenta#
+* [aqua]#cyan#
+* [white black-background]#white#
+|===
 
 Decoration and colors can be applied with overloaded +print+ and +println+ methods provided by the +ShellPrinterWriter+.
 This printer is available as the implicit _out_ attribute or thanks to the +<<command_context,context>>.getWriter()+
 method.
 
-[source,java]
+[source,groovy]
 .Decorating and coloring text
 ----
 out.println("hello", red); // <1>
@@ -496,24 +531,24 @@ out.println("hello", underline, red, blue); // <3>
 The combination of the decoration, background and foreground colors is a _style_ represented by the +org.crsh.text.Style+
 object. Styles can be used like decoration and colors:
 
-[source,java]
+[source,groovy]
 .Printing styled text
 ----
-out.println("hello", style(red)); <1>
-out.println("hello", style(red, blue)); <2>
-out.println("hello", style(underline, red, blue)); <3>
+out.println("hello", style(red)); // <1>
+out.println("hello", style(red, blue)); // <2>
+out.println("hello", style(underline, red, blue)); // <3>
 ----
 <1> Print hello in red color
 <2> Print hello in red with a red blue
 <3> Print hello in red underlined with a red blue
 
 When using the print methods, the style will be used for the currently printed object. It is possible to change the
-style permanently (until it is reset) using Groovy _leftshift_ operator : +<<+
+style permanently (until it is reset) using Groovy _leftshift_ operator: +<<+
 
 By default the +<<+ operator prints output on the console. The +ShellPrintWriter+ overrides the operator to work
 with color, decoration and styles:
 
-[source,java]
+[source,groovy]
 .Styling with the leftshift operator
 ----
 out << red // <1>
@@ -528,12 +563,12 @@ out << reset; // <4>
 
 Operators can also be combined on the same line providing a more compact syntax:
 
-[source,java]
+[source,groovy]
 ----
 out << red << underline << "hello" << reset
 ----
 
-[source,java]
+[source,groovy]
 ----
 out << style(underline, red, blue) << "hello" << reset
 ----
@@ -545,7 +580,7 @@ they can be used out of the box in any CRaSH command without requiring prior imp
 
 In this section we study how a command can reuse existing commands. Here is an example
 
-[source,java]
+[source,groovy]
 .dbscript.groovy
 ----
 jdbc.connect username:root, password:crash, "jdbc:derby:memory:EmbeddedDB;create=true"

--- a/doc/reference/src/main/asciidoc/extension.asciidoc
+++ b/doc/reference/src/main/asciidoc/extension.asciidoc
@@ -1,6 +1,6 @@
 == Embedding CRaSH
 
-The <<running,running chapter>> explains how to run CRaSH as a standalone or an embedded service. We will study in this section the technical
+The chapter <<running_crash>> explains how to run CRaSH as a standalone or an embedded service. We will study in this section the technical
 aspect of running application and show how CRaSH can be embedded in specific environments.
 
 The root class for reusing CRaSH is the +org.crsh.plugin.PluginLifeCycle+ class. This class is abstract and it cannot
@@ -14,16 +14,15 @@ file system (i.e +java.io.File+). It defines a specific layout for locating reso
 ** +org.crsh.spring.SpringBootstrap+ : embeds CRaSH as a Spring bean
 ** +org.crsh.spring.SpringWebBootstrap+ : extends the +SpringBootstrap+ and uses the existing +ServletContext+
 
-=== Standalone bootstrap
-
 [[standalone_bootstrap]]
+=== Standalone bootstrap
 
 The +org.crsh.standalone.Bootstrap+ class is a generic class that can be used to embed the shell in your Java programs
 Its usage is quite straighforward and configurable. The bootstrap is a coarse grained approach and it needs a bit of configuration for running:
 
 * The +baseLoader+ properties is the +java.lang.ClassLoader+ used by CRaSH for loading plugins, resources or command sources (under the
 _/crash/commands/_ path. This property is not modifiable and must be provided when the bootstrap is instantiated.
-* The +config+ properties provides the contextual properties used by CRaSH configuration such as //crash.vfs.refresh_period//
+* The +config+ properties provides the contextual properties used by CRaSH configuration such as _crash.vfs.refresh_period_
 * The +attributes+ property provides the contextual attributes used by CRaSH available at runtime via the +org.crsh.command.CommandContext+,
 it is useful for providing objects to commands in a similar fashion to servlet context attributes
 * The +cmdPath+ property is a list of +java.io.File+ scanned by CRaSH for loading additional commands
@@ -34,23 +33,44 @@ Let's see an example on how to use it
 === Standalone CRaSH
 
 The standalone shell is a Java class configurable and runnable from the command line that is used by the standalone distribution. It is
-built upon the ##<<standalone_bootstrap,StandaloneBoostrap>>## class.
-
-== Pluggable authentication
+built upon the <<standalone_bootstrap>>.
 
 [[pluggable_auth]]
+== Pluggable authentication
 
 Creating a custom authentication mechanism is done by implementing a CRaSH plugin that provides an implementation of the +AuthenticationPlugin+
-interface. Let's study the //simple// authentication plugin implementation.
+interface. Let's study the _simple_ authentication plugin implementation.
 
 The +AuthenticationPlugin+ is the interface to implement in order to integrate CRaSH with an authentication mechanism:
 
+////
 [source,java]
 ----
-{@include org.crsh.auth.AuthenticationPlugin}
+include::{sourcesdir}/org/crsh/auth/AuthenticationPlugin.java[tags=javadoc;classdef]
+----
+////
+
+[source,java]
+----
+include::{sourcesdir}/org/crsh/auth/AuthenticationPlugin.java[lines=24..-1]
 ----
 
 The integration as a CRaSH plugin mandates to extend the class +CRaSHPlugin+ with the generic type +AuthenticationPlugin+:
+
+////
+[source,java]
+----
+public class SimpleAuthenticationPlugin extends
+    CRaSHPlugin<AuthenticationPlugin> implements
+    AuthenticationPlugin {
+
+include::{sourcesdir}/org/crsh/auth/SimpleAuthenticationPlugin.java[tags=getName;getImplementation]
+
+  ...
+
+}
+----
+////
 
 [source,java]
 ----
@@ -58,22 +78,34 @@ public class SimpleAuthenticationPlugin extends
     CRaSHPlugin<AuthenticationPlugin> implements
     AuthenticationPlugin {
 
-{@include org.crsh.auth.SimpleAuthenticationPlugin#getName()}
-
-{@include org.crsh.auth.SimpleAuthenticationPlugin#getImplementation()}
+include::{sourcesdir}/org/crsh/auth/SimpleAuthenticationPlugin.java[lines=76..78;64..67]
 
   ...
 
 }
 ----
 
-* The +getName()+ method returns the //simple// value that matchs the //crash.auth// configuration property
+* The +getName()+ method returns the _simple_ value that matchs the _crash.auth_ configuration property
 * The +getImplementation()+ method returns the object that implements the +AuthenticationPlugin+ class, this method
 is implemented from the +CRaSHPlugin+ abstract class, but in our case it
-simply returns +this+ because +SimpleAuthenticationPlugin+ is
-directly the implementation class.
+simply returns +this+ because +SimpleAuthenticationPlugin+ is directly the implementation class.
 
 Now let's study how the plugin retrieves the configuration properties +crash.auth.simple.username+ and +crash.auth.simple.password+:
+
+////
+[source,java]
+----
+public class SimpleAuthenticationPlugin extends
+    CRaSHPlugin<AuthenticationPlugin> implements
+    AuthenticationPlugin {
+
+include::{sourcesdir}/org/crsh/auth/SimpleAuthenticationPlugin.java[tags=SIMPLE_USERNAME;SIMPLE_PASSWORD;createConfigurationCapabilities;init]
+
+  ...
+
+}
+----
+////
 
 [source,java]
 ----
@@ -81,17 +113,7 @@ public class SimpleAuthenticationPlugin extends
     CRaSHPlugin<AuthenticationPlugin> implements
     AuthenticationPlugin {
 
-{@include org.crsh.auth.SimpleAuthenticationPlugin#SIMPLE_USERNAME}
-
-{@include org.crsh.auth.SimpleAuthenticationPlugin#SIMPLE_PASSWORD}
-
-{@include org.crsh.auth.SimpleAuthenticationPlugin#createConfigurationCapabilities()}
-
-{@include org.crsh.auth.SimpleAuthenticationPlugin#username}
-
-{@include org.crsh.auth.SimpleAuthenticationPlugin#password}
-
-{@include org.crsh.auth.SimpleAuthenticationPlugin#init()}
+include::{sourcesdir}/org/crsh/auth/SimpleAuthenticationPlugin.java[lines=32..46;53..59;69..74]
 
   ...
 
@@ -105,9 +127,16 @@ from the plugin context with the method +getContext()+ available in the +CRaSHPl
 
 Finally the plugin needs to provide the +authenticate()+ method that implement the authentication logic:
 
-[source,java]
+////
+[source,java,indent=0]
 ----
-{@include org.crsh.auth.SimpleAuthenticationPlugin#authenticate(java.lang.String,java.lang.String)}
+include::{sourcesdir}/org/crsh/auth/SimpleAuthenticationPlugin.java[tags=authenticate]
+----
+////
+
+[source,java,indent=0]
+----
+include::{sourcesdir}/org/crsh/auth/SimpleAuthenticationPlugin.java[lines=80..86]
 ----
 
 The logic is straightforward with an equality check of the username and password.
@@ -123,5 +152,4 @@ org.crsh.auth.SimpleAuthenticationPlugin
 When all of this is done, the plugin and its service loader descriptor must be packaged in a jar file and available on the classpath
 of CRaSH.
 
-NOTE: You can learn more about the +java.util.ServiceLoader+ by looking at the online http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html[javadoc]
-
+NOTE: You can learn more about the +java.util.ServiceLoader+ by looking at the online http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html[javadoc].

--- a/doc/reference/src/main/asciidoc/groovy.asciidoc
+++ b/doc/reference/src/main/asciidoc/groovy.asciidoc
@@ -61,6 +61,7 @@ thread.ls
 === Passing options and arguments
 
 Command options and command arguments are passed as invocation parameters:
+
 * options are used as a map or named parameters
 * arguments are the other invocation parameters
 
@@ -137,7 +138,7 @@ log.send { m="hello"; ["the category"] }
 
 === Command pipeline
 
-The object pipeline can be used in the Groovy REPL using the **|** (pipe) operator. When a command closure is combined with a
+The object pipeline can be used in the Groovy REPL using the +|+ (pipe) operator. When a command closure is combined with a
  pipe, it returns a new closure that will invoke the pipeline construction.
 
 .Assembling a command pipe

--- a/doc/reference/src/main/asciidoc/jcr.asciidoc
+++ b/doc/reference/src/main/asciidoc/jcr.asciidoc
@@ -38,4 +38,4 @@ scp -P 2000 gadgets.xml root@localhost:portal:portal-system:/production/
 
 The exported file format use the JCR system view. You can get more information about that in the JCR specification.
 
-CAUTION: The SCP feature is experimental
+CAUTION: The SCP feature is experimental.

--- a/doc/reference/src/main/asciidoc/running.asciidoc
+++ b/doc/reference/src/main/asciidoc/running.asciidoc
@@ -12,6 +12,7 @@ in the application contains the standalone distribution.
 The bin directory _/crash/bin_ can be added to the system path, it contains the _crash.sh_ script that will start
 the standalone mode, for instance you can set it up this way:
 
+[subs="attributes,specialcharacters", options="nowrap"]
 ----
 > export PATH=/.../crash/bin:$PATH
 > crash.sh
@@ -19,11 +20,11 @@ the standalone mode, for instance you can set it up this way:
  .~      ~. |`````````,       .'.                   ..'''' |         |
 |           |'''|'''''      .''```.              .''       |_________|
 |           |    `.       .'       `.         ..'          |         |
- `.______.' |      `.   .'           `. ....''             |         | 1.0.0-cr2-SNAPSHOT
+ `.______.' |      `.   .'           `. ....''             |         | {crash-version}
 
 Follow and support the project on http://www.crashub.org
 Welcome to jerry + !
-It is Thu Apr 12 21:19:35 CEST 2012 now
+It is {localdatetime} now
 ----
 
 Let's review quickly what you can find in standalone crash:
@@ -37,8 +38,9 @@ Let's review quickly what you can find in standalone crash:
 
 The attach mode allows you to attach CRaSH to a JVM located on the same host with the attach API provided by the Hotspot
 JVM. It is the standalone mode attached to a running JVM specified by a process id. CRaSH will hook into the targetted JVM
-instead of the JVM started by CRaSH. Let's see quickly an example of how to use it
+instead of the JVM started by CRaSH. Let's see quickly an example of how to use it:
 
+[subs="attributes,specialcharacters", options="nowrap"]
 ----
 > jps
 3165 RemoteMavenServer
@@ -50,11 +52,11 @@ instead of the JVM started by CRaSH. Let's see quickly an example of how to use 
  .~      ~. |`````````,       .'.                   ..'''' |         |
 |           |'''|'''''      .''```.              .''       |_________|
 |           |    `.       .'       `.         ..'          |         |
- `.______.' |      `.   .'           `. ....''             |         | 1.0.0-cr2-SNAPSHOT
+ `.______.' |      `.   .'           `. ....''             |         | {crash-version}
 
 Follow and support the project on http://vietj.github.com/crash
 Welcome to jerry + !
-It is Thu Apr 12 22:09:23 CEST 2012 now
+It is {localdatetime} now
 %
 ----
 
@@ -116,8 +118,8 @@ The +org.crsh.standalone.CRaSH+ main has an optional list of arguments that are 
   are specified, CRaSH will dynamically attach to this virtual machine and will be executed in that machine. By default the two JVM will
   communicate with a socket unless the _non-interactive_ option is set.
 
-{{warning}}When more than one process id is specified, the _non-interactive_ option must be set because CRaSH will not be able
-to aggregate two command lines in the same terminal.{{/warning}}
+WARNING: When more than one process id is specified, the _non-interactive_ option must be set because CRaSH will not be able
+to aggregate two command lines in the same terminal.
 
 === Resource extraction
 
@@ -131,7 +133,7 @@ is specified, therefore
 * The _crash.sh_ or _crash.bat_ extracts the resources in the corresponding directory as the _cmd_ and _conf_ directories
 are specified
 
-To prevent any resource copying the value _read_ should be used/
+To prevent any resource copying the value _read_ should be used.
 
 == Embedded mode
 
@@ -142,7 +144,7 @@ and triggering the CRaSH life cycle start/stop. In this mode CRaSH has two packa
 
 * A __core__ war file found under _deploy/core/crash.war_ provides the base CRaSH functionnalities
 * A __gatein__ war file found under _deploy/gatein/crash.war_ provides additional Java Content Repository (JCR)
- features but deploys only in a GateIn server (Tomcat or JBoss). It extends the core packaging and adds
+  features but deploys only in a GateIn server (Tomcat or JBoss). It extends the core packaging and adds:
 ** JCR browsing and interactions
 ** SCP support for JCR import and export
 
@@ -162,7 +164,7 @@ If you want you can embed CRaSH in your own _web.xml_ configuration:
 
 === Embedding in Spring
 
-CRaSH can be easily embedded and configured in a Spring configuration
+CRaSH can be easily embedded and configured in a Spring configuration.
 
 ==== Embedding as a Spring bean
 

--- a/doc/reference/src/main/asciidoc/shell.asciidoc
+++ b/doc/reference/src/main/asciidoc/shell.asciidoc
@@ -1,16 +1,16 @@
 == Shell usage
 
+[[connection]]
 === Connection
 
-[[connection]]
-
-You need to connect using telnet, SSH or //directly// to use the
+You need to connect using telnet, SSH or _directly_ to use the
 shell.  The last method is a special mode using the JVM input and output.
 
 ==== Telnet access
 
 Telnet connection is done on port 5000:
 
+[subs="attributes,specialcharacters", options="nowrap"]
 ----
 (! 520)-> telnet localhost 5000
 Trying ::1...
@@ -20,25 +20,25 @@ Escape character is '^]'.
  .~      ~. |`````````,       .'.                   ..'''' |         |
 |           |'''|'''''      .''```.              .''       |_________|
 |           |    `.       .'       `.         ..'          |         |
- `.______.' |      `.   .'           `. ....''             |         | {version}
+ `.______.' |      `.   .'           `. ....''             |         | {crash-version}
 
 Follow and support the project on http://vietj.github.com/crash
 Welcome to julien.local + !
-It is Fri Dec 03 16:20:40 CET 2010 now
+It is {localdatetime} now
 ----
 
 The +bye+ command disconnect from the shell.
 
 ==== SSH access
 
-SSH connection is done on port 2000 with the password **//crash//**:
+SSH connection is done on port 2000 with the password *_crash_*:
 
 ----
 juliens-macbook-pro:~ julien$ ssh -p 2000 -l root localhost
 root@localhost's password:
-CRaSH {version} (http://vietj.github.com/crash)
+CRaSH {crash-version} (http://vietj.github.com/crash)
 Welcome to juliens-macbook-pro.local!
-It is Fri Jan 08 21:12:53 CET 2010 now.
+It is {localdatetime} now.
 %
 ----
 
@@ -54,8 +54,7 @@ JVM native input and output. When you run in standalone, CRaSh will be available
 * Line edition: the current line can be edited via left and right arrow keys
 * History: the key up and key down enable history browsing
 * Quoting: simple quotes or double quotes allow to insert blanks in command options and arguments, for instance
-//"old boy"// or //'old boy'//. One quote style can quote another,
-like //"hi, it's me"//.
++"old boy"+ or +'old boy'+. One quote style can quote another, like `"hi, it's me"`.
 * Completion: an advanced completion system is available
 
 == Command usage
@@ -188,8 +187,8 @@ and +<P>+:
 
 The command composition provides two operators:
 
-* The pipe operator **|** allows to stream a command output stream to a command input stream
-* The distribution operator **+** allows to distribute an input stream to several commands and to combine the output stream
+* The pipe operator `|` allows to stream a command output stream to a command input stream
+* The distribution operator `+` allows to distribute an input stream to several commands and to combine the output stream
 of several commands into a single stream.
 
 ==== Connecting a +<Void,Node>+ command to a +<Node,Void>+ command through a pipe

--- a/doc/reference/src/main/java/org/crsh/doc/Generator.java
+++ b/doc/reference/src/main/java/org/crsh/doc/Generator.java
@@ -64,18 +64,18 @@ public class Generator {
       if (cmd instanceof BaseShellCommand) {
         BaseShellCommand cc = (BaseShellCommand)cmd;
         CommandDescriptor<?> desc = cc.getDescriptor();
-        buffer.append("== ").append(desc.getName()).append("\n");
+        buffer.append("== ").append(desc.getName()).append("\n").append("\n");
         if (desc.getSubordinates().size() > 1) {
           for (CommandDescriptor<?> m : desc.getSubordinates().values()) {
-            buffer.append("=== ").append(desc.getName()).append(" ").append(m.getName()).append("\n");
+            buffer.append("=== ").append(desc.getName()).append(" ").append(m.getName()).append("\n").append("\n");
             buffer.append("----\n");
             m.printMan(buffer);
-            buffer.append("----\n");
+            buffer.append("----\n\n");
           }
         } else {
           buffer.append("----\n");
           desc.printMan(buffer);
-          buffer.append("----\n");
+          buffer.append("----\n\n");
         }
       }
     }


### PR DESCRIPTION
- migrate left over wikbook syntax
- fix xrefs
- set nowrap option on listing blocks showing CRaSH welcome message
- put anchors above sections
- fix lists that were being swallowed by preceding paragraph
- switch to CodeRay syntax highlighter
- set groovy language on Groovy listings
- enable section anchors
- use crash-version attribute for substituting library version
- use AsciiDoc include directives
- set sourcedir attribute for include directives
- add endlines in generator to space block elements
