### PR TITLE
Removed call to term init

### DIFF
--- a/shell/src/main/java/org/crsh/standalone/CRaSH.java
+++ b/shell/src/main/java/org/crsh/standalone/CRaSH.java
@@ -353,7 +353,6 @@ public class CRaSH {
 
       // Start crash for this command line
       final Terminal term = TerminalFactory.create();
-      term.init();
       ConsoleReader reader = new ConsoleReader(null, new FileInputStream(FileDescriptor.in), System.out, term);
       Runtime.getRuntime().addShutdownHook(new Thread(){
         @Override


### PR DESCRIPTION
It is already being called in JLine TerminalFactory

See here: https://github.com/jline/jline2/blob/jline-2.11/src/main/java/jline/TerminalFactory.java#L101
