### PR TITLE
Support interruption of command line editing

### DIFF
--- a/shell/src/main/java/org/crsh/processor/jline/JLineProcessor.java
+++ b/shell/src/main/java/org/crsh/processor/jline/JLineProcessor.java
@@ -20,6 +20,7 @@
 package org.crsh.processor.jline;
 
 import jline.console.ConsoleReader;
+import jline.console.UserInterruptException;
 import jline.console.completer.Completer;
 import org.crsh.cli.impl.completion.CompletionMatch;
 import org.crsh.cli.impl.Delimiter;
@@ -94,7 +95,12 @@ public class JLineProcessor implements Runnable, Completer {
 
   private void loop() {
     while (true) {
-      String line = readLine();
+      String line;
+      try {
+        line = readLine();
+      } catch (UserInterruptException e) {
+        continue;
+      }
 
       //
       ShellProcess process = shell.createProcess(line);

--- a/shell/src/main/java/org/crsh/standalone/CRaSH.java
+++ b/shell/src/main/java/org/crsh/standalone/CRaSH.java
@@ -365,6 +365,8 @@ public class CRaSH {
         }
       });
 
+      reader.setHandleUserInterrupt(true);
+
       AnsiConsole.systemInstall();
 
       final PrintWriter out = new PrintWriter(AnsiConsole.out);


### PR DESCRIPTION
This affects standalone mode.

In most of popular shells when you are entering a command and you press
Ctrl+C (intr) the shell starts a new prompt below and the old text is visible
above. This behavior is present when connecting over ssh to crsh.

This patch leverages jline feature which allows to enable interruption of
readline() invocations.
