### PR TITLE
SSH: Fix usage of ssh.keypath for hostkey

### DIFF
--- a/connectors/ssh/src/main/java/org/crsh/ssh/SSHPlugin.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/SSHPlugin.java
@@ -97,8 +97,11 @@ public class SSHPlugin extends CRaSHPlugin<SSHPlugin> {
       if (f.exists() && f.isFile()) {
         try {
           serverKeyURL = f.toURI().toURL();
+          serverKey = new Resource("hostkey.pem", serverKeyURL);
         } catch (MalformedURLException e) {
           log.log(Level.FINE, "Ignoring invalid server key " + serverKeyPath, e);
+        } catch (IOException e) {
+          log.log(Level.FINE, "Could not load SSH key from " + serverKeyPath, e);
         }
       } else {
         log.log(Level.FINE, "Ignoring invalid server key path " + serverKeyPath);


### PR DESCRIPTION
serverKey resource wasn't being set when ssh.keypath property was used. This
made the plugin basically ignore a key that is being set from a property.
