### PR TITLE
Standalone: Use ansi console only if not supported

### DIFF
--- a/shell/src/main/java/org/crsh/standalone/CRaSH.java
+++ b/shell/src/main/java/org/crsh/standalone/CRaSH.java
@@ -365,11 +365,17 @@ public class CRaSH {
         }
       });
 
-      AnsiConsole.systemInstall();
+      // Use AnsiConsole only if term doesn't support Ansi
+      PrintStream out = System.out;
+      PrintStream err = System.err;
+      if (!term.isAnsiSupported()) {
+        out = AnsiConsole.out;
+        err = AnsiConsole.err;
+      }
 
       //
       FileInputStream in = new FileInputStream(FileDescriptor.in);
-      final JLineProcessor processor = new JLineProcessor( shell, in, AnsiConsole.out, AnsiConsole.err, term);
+      final JLineProcessor processor = new JLineProcessor( shell, in, out, err, term);
 
       // Install signal handler
 //      InterruptHandler ih = new InterruptHandler(new Runnable() {
@@ -387,9 +393,6 @@ public class CRaSH {
         t.printStackTrace();
       }
       finally {
-
-        //
-        AnsiConsole.systemUninstall();
 
         //
         if (closeable != null) {


### PR DESCRIPTION
- Use ansi console for stdout and stderr only if it is not supported in the
  terminal instance provided by JLine.
- Remove usage of AnsiConsole.systemInstall().
  Since we control which print streams are provided for JLine, it is not
  necessary to install them in System, so I used System.out and System.err
  or AnsiConsole.out and AnsiConsole.err (depends on Ansi support in term).
