### PR TITLE
Standalone: Removed call to term.init()

### DIFF
--- a/shell/src/main/java/org/crsh/standalone/CRaSH.java
+++ b/shell/src/main/java/org/crsh/standalone/CRaSH.java
@@ -353,7 +353,6 @@ public class CRaSH {
       // Start crash for this command line
       jline.TerminalFactory.registerFlavor(jline.TerminalFactory.Flavor.UNIX, NoInterruptUnixTerminal.class);
       final Terminal term = TerminalFactory.create();
-      term.init();
       Runtime.getRuntime().addShutdownHook(new Thread(){
         @Override
         public void run() {


### PR DESCRIPTION
It is already being called in JLine TerminalFactory.create().
