### PR TITLE
dashboard: Remove GC spaces list print

### DIFF
--- a/shell/src/main/resources/crash/commands/base/dashboard.groovy
+++ b/shell/src/main/resources/crash/commands/base/dashboard.groovy
@@ -49,6 +49,7 @@ def table = new UIBuilder().table(columns: [1], rows: [1,1]) {
                 execute("jvm pool '$name'")
               }
             }
+            null
           })()
         }
       }


### PR DESCRIPTION
When using the dashboard command, a list of gc pools is printed to screen
before the main table layout is shown.

This is caused because of `(jvm.pools | { name -> .. })()`. The closure, in
this case, returns the name of the pool in question. This causes it to be
printed to screen while the UIBuilder.table() is generated.

Explicitly placing "null" at the end of the closure makes Groovy consider this
as the return value, thus nothing gets printed to screen before the dashboard
is displayed.
