### PR TITLE
Add exit status to ERROR when the shell process finishes with a response...

### DIFF
--- a/shell/ssh/src/main/java/org/crsh/ssh/term/inline/SSHInlineCommand.java
+++ b/shell/ssh/src/main/java/org/crsh/ssh/term/inline/SSHInlineCommand.java
@@ -91,6 +91,8 @@ public class SSHInlineCommand extends AbstractCommand implements Runnable {
       }
       else {
         String errorMsg;
+          // Set the exit status to Error
+        exitStatus = ERROR;
         if (response != null) {
           errorMsg = "Error during command execution : " + response.getMessage();
         }


### PR DESCRIPTION
Add exit status to ERROR when the shell process finishes with a response different than ShellResponse.OK

We can then use the exit status in shells scripts to get the command execution status
