### PR TITLE
Return null when JLine.readLine() returns null

### DIFF
--- a/shell/src/main/java/org/crsh/processor/jline/JLineProcessor.java
+++ b/shell/src/main/java/org/crsh/processor/jline/JLineProcessor.java
@@ -230,7 +230,7 @@ public class JLineProcessor implements Runnable, Completer {
       checkInterrupt();
       String line = reader.readLine(prompt);
       if (line == null) {
-        break;
+        return null;
       } else {
         lineBuffer.append(line);
         if (lineBuffer.crlf()) {


### PR DESCRIPTION
Hitting ^D causes the shell to continously prompt without an option to close it
other then killing the process.

Previously, when JLine.readLine() returned null, so did
JLineProcessor.readAndParseCommand. This caused the main processor loop break
(line #316) and end the shell. 17bb13a (CRASH-166 : Multiline term input) changed
that and made it return an empty string when ^D caused the end of input.

This patch simply returns null when JLine.readLine() returns null.
