### PR TITLE
CRASH-188 : Use current bouncycastle artifacts (bcprov-jdk16 is deprecat...

### DIFF
--- a/connectors/ssh/pom.xml
+++ b/connectors/ssh/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk16</artifactId>
+      <artifactId>bcprov-jdk15on</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.mina</groupId>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk16</artifactId>
+      <artifactId>bcprov-jdk15on</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.mina</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,7 @@
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk16</artifactId>
+        <artifactId>bcprov-jdk15on</artifactId>
         <version>1.46</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
...ed and replaced by bcprov-jdk15on).
