### PR TITLE
Update bouncycastle to 1.49

### DIFF
--- a/connectors/ssh/pom.xml
+++ b/connectors/ssh/pom.xml
@@ -35,7 +35,11 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk16</artifactId>
+      <artifactId>bcprov-jdk15on</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.mina</groupId>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -75,7 +75,11 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk16</artifactId>
+      <artifactId>bcprov-jdk15on</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.mina</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -463,8 +463,13 @@
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk16</artifactId>
-        <version>1.46</version>
+        <artifactId>bcprov-jdk15on</artifactId>
+        <version>1.49</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk15on</artifactId>
+        <version>1.49</version>
       </dependency>
       <dependency>
         <groupId>net.wimpi</groupId>


### PR DESCRIPTION
This commit updates bouncycastle to 1.49 and use the standard artifact
names. The openssl support has moved to a separate artifact, 'bcpkix'
which has been added as well.

Issue: CRASH-188
