### PR TITLE
- Handle abstract and lazy beans with care and return null value for now

### DIFF
--- a/embed/spring/src/main/java/org/crsh/spring/SpringMap.java
+++ b/embed/spring/src/main/java/org/crsh/spring/SpringMap.java
@@ -21,6 +21,8 @@ package org.crsh.spring;
 
 import org.crsh.util.SimpleMap;
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,11 +43,21 @@ class SpringMap extends SimpleMap<String, Object> {
     return Arrays.asList(factory.getBeanDefinitionNames()).iterator();
   }
 
-  @Override
-  public Object get(Object key) {
-    if (key instanceof String) {
-      return factory.getBean(((String)key));
+   @Override
+   public Object get(Object key) {
+     Object bean = null;
+     if (key instanceof String) {
+       String sKey = (String) key;
+       if (this.factory instanceof DefaultListableBeanFactory) {
+         DefaultListableBeanFactory defaultFactory = (DefaultListableBeanFactory) factory;
+         BeanDefinition beanDef = defaultFactory.getBeanDefinition(sKey);
+         if (!beanDef.isAbstract() && !beanDef.isLazyInit()) {
+           bean = factory.getBean(sKey);
+         }
+       } else {
+         bean = factory.getBean(sKey);
+       }
+     }
+     return bean;
     }
-    return null;
-  }
 }


### PR DESCRIPTION
Abstract  and lazy bean values should get special treatment. Getting them from the factory  throws an Exception/may force undesired initialization. The patch initializes them with a null value. You can still examine them in client code (spring.groovy)  where you may  get a reference to the BeanDef. Another options could be to (temporarily) initialize them with an enum value.
