### PR TITLE
Apply @Named annotations to the global command scope. Stop console disconnects writing to stderr. 

### DIFF
--- a/shell/src/main/java/org/crsh/console/jline/JLineProcessor.java
+++ b/shell/src/main/java/org/crsh/console/jline/JLineProcessor.java
@@ -24,6 +24,7 @@ import jline.console.ConsoleReader;
 import jline.console.KeyMap;
 import jline.console.Operation;
 import jline.internal.NonBlockingInputStream;
+
 import org.crsh.console.Console;
 import org.crsh.console.ConsoleDriver;
 import org.crsh.shell.Shell;
@@ -33,9 +34,14 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Stack;
 import java.util.concurrent.CountDownLatch;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class JLineProcessor implements Runnable, ConsoleDriver {
 
+  /** . */
+  final Logger log = Logger.getLogger(getClass().getName());
+  
   /** . */
   private final Console console;
 
@@ -207,7 +213,7 @@ public class JLineProcessor implements Runnable, ConsoleDriver {
         }
       }
       catch (IOException e) {
-        e.printStackTrace();
+        log.log(Level.INFO, "console has disconnected", e);
         return;
       }
     }

--- a/shell/src/main/java/org/crsh/lang/LanguageCommandResolver.java
+++ b/shell/src/main/java/org/crsh/lang/LanguageCommandResolver.java
@@ -31,8 +31,10 @@ import org.crsh.util.TimestampedObject;
 import org.crsh.vfs.Resource;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -123,7 +125,21 @@ public class LanguageCommandResolver implements CommandResolver {
   @Override
   public Command<?> resolveCommand(String name) throws CommandException, NullPointerException {
     if (commandAliasMap.containsKey(name)) {
+      // exact alias match
       name = commandAliasMap.get(name);
+    } else {
+      // look for a unique matching prefix
+      final Set<String> prefixMatch = new HashSet<String>();
+      for (String alias : commandAliasMap.keySet()) {
+        if(alias.startsWith(name)) {
+          prefixMatch.add(alias);
+        }
+      }
+      // if a single matching alias has been found use its command 
+      if(prefixMatch.size() == 1) {
+        String alias = prefixMatch.iterator().next();
+        name = commandAliasMap.get(alias);
+      }
     }
     CommandResolution resolution = resolveCommand2(name);
     return resolution != null ? resolution.getCommand() : null;


### PR DESCRIPTION
This pull request contains 2 changes. Could you please check them out and let me know what you think. 
1. Named related change in LanguageCommandResolver to allow the Named annotation to be used by the global command names. It also accepts prefix abbreviated names if they match a unique command. Disclaimer: I've only tested it with Java commands. 
2. On console disconnect stop printing IOException stack traces to standard error - use a logger. I set to INFO since I don't think a console disconnect should trigger a warning or errror. Observation: the CRaSH logging seems a bit erratic, some to stdout/err and at other times using java.util.logging. 
