### PR TITLE
SSH host property added

### DIFF
--- a/connectors/ssh/src/main/java/org/crsh/ssh/SSHPlugin.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/SSHPlugin.java
@@ -50,6 +50,9 @@ public class SSHPlugin extends CRaSHPlugin<SSHPlugin> {
   /** The SSH server authentication timeout value. */
   private static final int SSH_SERVER_AUTH_DEFAULT_TIMEOUT = 10 * 60 * 1000;
 
+  /** The SSH host. */
+  public static final PropertyDescriptor<String> SSH_HOST = PropertyDescriptor.create("ssh.host", (String)null, "The SSH host");
+
   /** The SSH port. */
   public static final PropertyDescriptor<Integer> SSH_PORT = PropertyDescriptor.create("ssh.port", 2000, "The SSH port");
 
@@ -83,7 +86,7 @@ public class SSHPlugin extends CRaSHPlugin<SSHPlugin> {
 
   @Override
   protected Iterable<PropertyDescriptor<?>> createConfigurationCapabilities() {
-    return Arrays.<PropertyDescriptor<?>>asList(SSH_PORT, SSH_SERVER_KEYPATH, SSH_SERVER_KEYGEN, SSH_SERVER_AUTH_TIMEOUT,
+    return Arrays.<PropertyDescriptor<?>>asList(SSH_HOST, SSH_PORT, SSH_SERVER_KEYPATH, SSH_SERVER_KEYGEN, SSH_SERVER_AUTH_TIMEOUT,
         SSH_SERVER_IDLE_TIMEOUT, SSH_ENCODING, AuthenticationPlugin.AUTH);
   }
 
@@ -91,6 +94,9 @@ public class SSHPlugin extends CRaSHPlugin<SSHPlugin> {
   public void init() {
 
     SecurityUtils.setRegisterBouncyCastle(true);
+    //
+    String host = getContext().getProperty(SSH_HOST);
+
     //
     Integer port = getContext().getProperty(SSH_PORT);
     if (port == null) {
@@ -186,6 +192,7 @@ public class SSHPlugin extends CRaSHPlugin<SSHPlugin> {
     SSHLifeCycle lifeCycle = new SSHLifeCycle(
         getContext(),
         encoding,
+        host,
         port,
         idleTimeout,
         authTimeout,

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
@@ -57,6 +57,9 @@ public class SSHLifeCycle {
   private final PluginContext context;
 
   /** . */
+  private final String host;
+
+  /** . */
   private final int port;
 
   /** . */
@@ -83,6 +86,7 @@ public class SSHLifeCycle {
   public SSHLifeCycle(
       PluginContext context,
       Charset encoding,
+      String host,
       int port,
       int idleTimeout,
       int authTimeout,
@@ -91,6 +95,7 @@ public class SSHLifeCycle {
     this.authenticationPlugins = authenticationPlugins;
     this.context = context;
     this.encoding = encoding;
+    this.host = host;
     this.port = port;
     this.idleTimeout = idleTimeout;
     this.authTimeout = authTimeout;
@@ -99,6 +104,10 @@ public class SSHLifeCycle {
 
   public Charset getEncoding() {
     return encoding;
+  }
+
+  public String getHost() {
+    return host;
   }
 
   public int getPort() {
@@ -134,6 +143,7 @@ public class SSHLifeCycle {
 
       //
       SshServer server = SshServer.setUpDefaultServer();
+      server.setHost(host);
       server.setPort(port);
 
       if (this.idleTimeout > 0) {


### PR DESCRIPTION
By default, the behaviour is the same as before, i.e. all network interfaces are bound.
When a host is set, only the network interfaces matching this host will be bound.
For instance, this can be useful when one wants its server to be exposed only on localhost for security purposes.
