### PR TITLE
Copy/Paste multiple lines of commands

### DIFF
--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/CRaSHCommand.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/CRaSHCommand.java
@@ -18,8 +18,8 @@
  */
 package org.crsh.ssh.term;
 
-import org.crsh.console.jline.Terminal;
-import org.crsh.console.jline.console.ConsoleReader;
+import jline.Terminal;
+import jline.console.ConsoleReader;
 import org.apache.sshd.server.Environment;
 import org.crsh.console.jline.JLineProcessor;
 import org.crsh.shell.Shell;
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
 import java.security.Principal;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;

--- a/shell/src/main/java/org/crsh/console/Console.java
+++ b/shell/src/main/java/org/crsh/console/Console.java
@@ -231,7 +231,15 @@ public class Console {
               }
             }
           } else {
-            KeyHandler keyHandler = processHandler.process.getKeyHandler();
+            KeyHandler keyHandler = null;
+            try {
+              keyHandler = processHandler.process.getKeyHandler();
+            } catch (IllegalStateException ignored) {
+              // Ignoring the illegal state exception. The ProcessHandler is of
+              // the previous command and terminated.
+              // The keyhandler will remain null and the input will be appended
+              // to the buffer.
+            }
             if (keyHandler != null) {
               KeyType type = key.map();
               try {


### PR DESCRIPTION
I have noticed for several versions that it is not possible to 'copy / paste' multiple lines of commands into the shell.
Tested this on Linux (Ubuntu) and Windows, with:
- The standalone version: displays an exception and renders the shell blocked
- SSH: disconnects.

I traced it down to the state machine, where the code tries to get a keyHandler on the processHandler of the first command (which is terminated).
Catching the exception seems let the pasted text go into the buffer and all is fine afterwards!
