### PR TITLE
Code quality fix - Private function that don't use instance data should be static

### DIFF
--- a/cli/src/main/java/org/crsh/cli/impl/completion/CompletionMatcher.java
+++ b/cli/src/main/java/org/crsh/cli/impl/completion/CompletionMatcher.java
@@ -51,7 +51,7 @@ public final class CompletionMatcher<T> {
     return getCompletion(completer, s).complete();
   }
 
-  private Completion argument(CommandDescriptor<?> method, Completer completer, Delimiter delimiter) {
+  private static Completion argument(CommandDescriptor<?> method, Completer completer, Delimiter delimiter) {
     List<? extends ArgumentDescriptor> arguments = method.getArguments();
     if (arguments.isEmpty()) {
       return new EmptyCompletion();

--- a/cli/src/main/java/org/crsh/cli/impl/invocation/InvocationMatcher.java
+++ b/cli/src/main/java/org/crsh/cli/impl/invocation/InvocationMatcher.java
@@ -173,7 +173,7 @@ public class InvocationMatcher<T> {
     return current;
   }
 
-  private List<LiteralValue> bilto(List<? extends Token.Literal> literals) {
+  private static List<LiteralValue> bilto(List<? extends Token.Literal> literals) {
     List<LiteralValue> values = new ArrayList<LiteralValue>(literals.size());
     for (Token.Literal literal : literals) {
       values.add(new LiteralValue(literal.getRaw(), literal.getValue()));

--- a/connectors/ssh/src/main/java/org/crsh/auth/FilePublicKeyProvider.java
+++ b/connectors/ssh/src/main/java/org/crsh/auth/FilePublicKeyProvider.java
@@ -81,7 +81,7 @@ class FilePublicKeyProvider extends AbstractKeyPairProvider {
     return keys;
   }
 
-  private KeyPair convertPemKeyPair(PEMKeyPair pemKeyPair) throws PEMException {
+  private static KeyPair convertPemKeyPair(PEMKeyPair pemKeyPair) throws PEMException {
     JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
     return new KeyPair(converter.getPublicKey(pemKeyPair.getPublicKeyInfo()), null);
   }

--- a/plugins/cron/src/main/java/org/crsh/cron/CronPlugin.java
+++ b/plugins/cron/src/main/java/org/crsh/cron/CronPlugin.java
@@ -213,7 +213,7 @@ public class CronPlugin extends CRaSHPlugin<CronPlugin> implements TaskCollector
     return table;
   }
 
-  private CRaSHTaskDef validateAndParseCronLine(String cronLine) {
+  private static CRaSHTaskDef validateAndParseCronLine(String cronLine) {
 
     //
     cronLine = cronLine.trim();

--- a/shell/src/main/java/org/crsh/lang/impl/groovy/GroovyCompiler.java
+++ b/shell/src/main/java/org/crsh/lang/impl/groovy/GroovyCompiler.java
@@ -88,7 +88,7 @@ public class GroovyCompiler implements org.crsh.lang.spi.Compiler {
     return shell;
   }
 
-  private String eval(ShellSession session, String name, String def) {
+  private static String eval(ShellSession session, String name, String def) {
     try {
       GroovyShell shell = getGroovyShell(session);
       Object ret = shell.getContext().getVariable(name);
@@ -197,11 +197,11 @@ public class GroovyCompiler implements org.crsh.lang.spi.Compiler {
     };
   }
 
-  private <C extends BaseCommand> ClassShellCommand<C> make(Class<C> clazz) throws IntrospectionException {
+  private static <C extends BaseCommand> ClassShellCommand<C> make(Class<C> clazz) throws IntrospectionException {
     return new ClassShellCommand<C>(clazz);
   }
 
-  private <C extends GroovyScriptCommand> GroovyScriptShellCommand<C> make2(Class<C> clazz) throws IntrospectionException {
+  private static <C extends GroovyScriptCommand> GroovyScriptShellCommand<C> make2(Class<C> clazz) throws IntrospectionException {
     return new GroovyScriptShellCommand<C>(clazz);
   }
 }

--- a/shell/src/main/java/org/crsh/standalone/CRaSH.java
+++ b/shell/src/main/java/org/crsh/standalone/CRaSH.java
@@ -85,7 +85,7 @@ public class CRaSH {
     this.descriptor = CommandFactory.DEFAULT.create(CRaSH.class);
   }
 
-  private void copyCmd(org.crsh.vfs.File src, File dst) throws IOException {
+  private static void copyCmd(org.crsh.vfs.File src, File dst) throws IOException {
     if (src.hasChildren()) {
       if (!dst.exists()) {
         if (dst.mkdir()) {
@@ -108,7 +108,7 @@ public class CRaSH {
     }
   }
 
-  private void copyConf(org.crsh.vfs.File src, File dst) throws IOException {
+  private static void copyConf(org.crsh.vfs.File src, File dst) throws IOException {
     if (!src.hasChildren()) {
       if (!dst.exists()) {
         Resource resource = ResourceManager.loadConf(src);
@@ -120,7 +120,7 @@ public class CRaSH {
     }
   }
 
-  private String toString(FS.Builder builder) {
+  private static String toString(FS.Builder builder) {
     StringBuilder sb = new StringBuilder();
     List<Mount<?>> mounts = builder.getMounts();
     for (int i = 0;i < mounts.size();i++) {
@@ -133,7 +133,7 @@ public class CRaSH {
     return sb.toString();
   }
 
-  private FS.Builder createBuilder() throws IOException {
+  private static FS.Builder createBuilder() throws IOException {
     FileMountFactory fileDriver = new FileMountFactory(Utils.getCurrentDirectory());
     ClassPathMountFactory classpathDriver = new ClassPathMountFactory(Thread.currentThread().getContextClassLoader());
     return new FS.Builder().register("file", fileDriver).register("classpath", classpathDriver);

--- a/shell/src/main/java/org/crsh/text/RenderAppendable.java
+++ b/shell/src/main/java/org/crsh/text/RenderAppendable.java
@@ -149,7 +149,7 @@ public class RenderAppendable implements ScreenContext {
     return merged;
   }
 
-  private Boolean foo(Boolean last, Boolean merged) {
+  private static Boolean foo(Boolean last, Boolean merged) {
     if (last != null) {
       if (merged != null) {
         return merged;
@@ -161,7 +161,7 @@ public class RenderAppendable implements ScreenContext {
     }
   }
 
-  private Color foo(Color last, Color merged, Color def) {
+  private static Color foo(Color last, Color merged, Color def) {
     if (last != null) {
       if (merged != null) {
         return merged;

--- a/shell/src/main/java/org/crsh/util/CharSlicer.java
+++ b/shell/src/main/java/org/crsh/util/CharSlicer.java
@@ -63,7 +63,7 @@ public class CharSlicer {
     return lines(linesIterator(width), 0);
   }
 
-  private Pair<Integer, Integer>[] lines(Iterator<Pair<Integer, Integer>> i, int count) {
+  private static Pair<Integer, Integer>[] lines(Iterator<Pair<Integer, Integer>> i, int count) {
     Pair<Integer, Integer>[] lines;
     if (i.hasNext()) {
       Pair<Integer, Integer> n = i.next();

--- a/shell/src/main/java/org/crsh/vfs/File.java
+++ b/shell/src/main/java/org/crsh/vfs/File.java
@@ -143,7 +143,7 @@ public final class File {
     }
   }
 
-  private <H> H resolve(FSDriver<H> driver, H current, Path path) throws IOException {
+  private static <H> H resolve(FSDriver<H> driver, H current, Path path) throws IOException {
     int index = 0;
     while (current != null && index < path.getSize()) {
       String name = path.nameAt(index++);

--- a/shell/src/main/java/org/crsh/vfs/spi/servlet/ServletContextDriver.java
+++ b/shell/src/main/java/org/crsh/vfs/spi/servlet/ServletContextDriver.java
@@ -120,7 +120,7 @@ public class ServletContextDriver extends AbstractFSDriver<String> {
     return Utils.iterator(ctx.getResource(handle).openConnection().getInputStream());
   }
 
-  private Matcher assertMatch(String path) {
+  private static Matcher assertMatch(String path) {
     Matcher m = pathPattern.matcher(path);
     if (m.matches()) {
       return m;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.
Zeeshan
