### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/cli/src/main/java/org/crsh/cli/impl/lang/Util.java
+++ b/cli/src/main/java/org/crsh/cli/impl/lang/Util.java
@@ -27,7 +27,11 @@ import java.util.NoSuchElementException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class Util {
+public final class Util {
+	
+  private Util(){
+	  throw new AssertionError("Must not instantiate this class");
+  }
 
   /** . */
   static final Object[] EMPTY_ARGS = new Object[0];

--- a/connectors/ssh/src/main/java/org/crsh/ssh/util/KeyPairUtils.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/util/KeyPairUtils.java
@@ -23,7 +23,12 @@ import org.bouncycastle.util.io.pem.PemReader;
 import java.io.Reader;
 
 /** @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a> */
-public class KeyPairUtils {
+public final class KeyPairUtils {
+	
+	private KeyPairUtils(){
+		throw new AssertionError("Must not instantiate this class");
+	}
+	
     public static Object readKey(Reader reader) throws Exception {
         try {
             PEMParser pemParser = new PEMParser(reader);

--- a/shell/src/main/java/org/crsh/lang/impl/groovy/Helper.java
+++ b/shell/src/main/java/org/crsh/lang/impl/groovy/Helper.java
@@ -33,7 +33,11 @@ import org.crsh.util.SafeCallable;
 /**
  * @author Julien Viet
  */
-public class Helper {
+public final class Helper {
+	
+  public Helper(){
+	  throw new AssertionError("Must not instantiate this class");
+  }
 
   public static Object invokeMethod(RuntimeContext context, String name, Object args, MissingMethodException ex) {
     if (context instanceof InvocationContext<?>) {

--- a/shell/src/main/java/org/crsh/util/JNDIHandler.java
+++ b/shell/src/main/java/org/crsh/util/JNDIHandler.java
@@ -11,7 +11,11 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 /** @author <a href="mailto:alain.defrance@exoplatform.com">Alain Defrance</a> */
-public class JNDIHandler {
+public final class JNDIHandler {
+	
+  private JNDIHandler(){
+	  throw new AssertionError("Must not instantiate this class");
+  }
 
   public static List<BindingRenderer.BindingData> lookup(List<String> filters, String name, Boolean verbose) {
 

--- a/shell/src/main/java/org/crsh/util/Utils.java
+++ b/shell/src/main/java/org/crsh/util/Utils.java
@@ -47,7 +47,11 @@ import java.util.NoSuchElementException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class Utils {
+public final class Utils {
+	
+  private Utils(){
+	  throw new AssertionError("Must not instantiate this class");
+  }
 
   /** . */
   private static final Iterator EMPTY_ITERATOR = Collections.emptyList().iterator();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#rule_key=squid:S1118

Please let me know if you have any questions.

Zeeshan
