### PR TITLE
Code Improvements: close resources & remove unused local vars

### DIFF
--- a/cli/src/main/java/org/crsh/cli/impl/completion/CompletionMatcher.java
+++ b/cli/src/main/java/org/crsh/cli/impl/completion/CompletionMatcher.java
@@ -103,7 +103,6 @@ public final class CompletionMatcher<T> {
       return new OptionCompletion<T>(foo, nso.getToken());
     } else if (stop instanceof Event.Stop.Unresolved) {
       if (stop instanceof Event.Stop.Unresolved.TooManyArguments) {
-        Event.Stop.Unresolved.TooManyArguments tma = (Event.Stop.Unresolved.TooManyArguments)stop;
         return new CommandCompletion<T>(foo, s.substring(stop.getIndex()), delimiter);
       } else {
         return new EmptyCompletion();

--- a/plugins/cron/src/main/java/org/crsh/cron/CronPlugin.java
+++ b/plugins/cron/src/main/java/org/crsh/cron/CronPlugin.java
@@ -182,9 +182,10 @@ public class CronPlugin extends CRaSHPlugin<CronPlugin> implements TaskCollector
     //
     Resource res = getConfig();
     List<String> lines = null;
+    BufferedReader reader = null;
     try {
       lines = new ArrayList<String>();
-      BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(res.getContent()), "UTF-8"));
+      reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(res.getContent()), "UTF-8"));
       while (true) {
         String cronLine = reader.readLine();
         if (cronLine == null) {
@@ -196,6 +197,16 @@ public class CronPlugin extends CRaSHPlugin<CronPlugin> implements TaskCollector
     }
     catch (IOException e) {
       log.log(Level.FINE, "Could not read cron file", e);
+    }
+    finally {
+      if(reader != null) {
+        try {
+	      reader.close();
+        }
+	    catch (IOException e){
+	   	  log.log(Level.FINE, "Exception while closing reading ", e);
+	    }
+      }
     }
 
     //

--- a/shell/src/main/java/org/crsh/lang/impl/groovy/GroovyRepl.java
+++ b/shell/src/main/java/org/crsh/lang/impl/groovy/GroovyRepl.java
@@ -47,7 +47,6 @@ public class GroovyRepl implements Repl {
 
   public GroovyRepl(GroovyLanguage lang) {
     // Force to load Groovy here or fail
-    Object o = GroovyShell.class;
     this.lang = lang;
   }
 

--- a/shell/src/main/java/org/crsh/lang/impl/script/ScriptCompiler.java
+++ b/shell/src/main/java/org/crsh/lang/impl/script/ScriptCompiler.java
@@ -188,6 +188,7 @@ public class ScriptCompiler implements Compiler {
                         invoker.invoke(consumer);
                       }
                     }
+                    reader.close();
 
                     //
                     try {

--- a/shell/src/main/java/org/crsh/standalone/CRaSH.java
+++ b/shell/src/main/java/org/crsh/standalone/CRaSH.java
@@ -370,8 +370,8 @@ public class CRaSH {
       String encoding = Configuration.getEncoding();
 
       // Use AnsiConsole only if term doesn't support Ansi
-      PrintStream out;
-      PrintStream err;
+      PrintStream out = null;
+      PrintStream err = null;
       boolean ansi;
       if (term.isAnsiSupported()) {
         out = new PrintStream(new BufferedOutputStream(term.wrapOutIfNeeded(new FileOutputStream(FileDescriptor.out)), 16384), false, encoding);
@@ -412,6 +412,14 @@ public class CRaSH {
         t.printStackTrace();
       }
       finally {
+    	  
+    	if(out != null){
+    	  out.close();
+    	}
+    	  
+    	if(err != null){
+    	  err.close();
+    	}
 
         //
         if (closeable != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2095 resources should be closed
squid:S1481 Unused local variables should be removed

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#rule_key=squid:S2095
https://dev.eclipse.org/sonar/coding_rules#rule_key=squid:S1481

Please let me know if you have any questions.

Zeeshan
