### PR TITLE
Code Improvements: constant fields & declare general interfaces

### DIFF
--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
@@ -36,6 +36,7 @@ import org.crsh.ssh.term.subsystem.SubsystemFactoryPlugin;
 import java.nio.charset.Charset;
 import java.security.PublicKey;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -87,8 +88,8 @@ public class SSHLifeCycle {
       int idleTimeout,
       int authTimeout,
       KeyPairProvider keyPairProvider,
-      ArrayList<AuthenticationPlugin> authenticationPlugins) {
-    this.authenticationPlugins = authenticationPlugins;
+      List<AuthenticationPlugin> authenticationPlugins) {
+    this.authenticationPlugins = (ArrayList<AuthenticationPlugin>) authenticationPlugins;
     this.context = context;
     this.encoding = encoding;
     this.port = port;

--- a/plugins/cron/src/main/java/org/crsh/cron/CronPlugin.java
+++ b/plugins/cron/src/main/java/org/crsh/cron/CronPlugin.java
@@ -50,7 +50,7 @@ import java.util.logging.Logger;
 /** @author Benjamin Prato */
 public class CronPlugin extends CRaSHPlugin<CronPlugin> implements TaskCollector {
 
-  public static PropertyDescriptor<String> CRON_CONFIG_PATH = new PropertyDescriptor<String>(String.class, "cron.config.path", null, "The contrab file path") {
+  public static final PropertyDescriptor<String> CRON_CONFIG_PATH = new PropertyDescriptor<String>(String.class, "cron.config.path", null, "The contrab file path") {
     @Override
     protected String doParse(String s) throws Exception {
       return s;

--- a/plugins/mail/src/main/java/org/crsh/mail/MailPlugin.java
+++ b/plugins/mail/src/main/java/org/crsh/mail/MailPlugin.java
@@ -49,7 +49,7 @@ import java.util.concurrent.Future;
 public class MailPlugin extends CRaSHPlugin<MailPlugin> {
 
   /** . */
-  public static PropertyDescriptor<String> SMTP_HOST = new PropertyDescriptor<String>(String.class, "mail.smtp.host", "localhost", "The mail server host") {
+  public static final PropertyDescriptor<String> SMTP_HOST = new PropertyDescriptor<String>(String.class, "mail.smtp.host", "localhost", "The mail server host") {
     @Override
     protected String doParse(String s) throws Exception {
       return s;
@@ -57,7 +57,7 @@ public class MailPlugin extends CRaSHPlugin<MailPlugin> {
   };
 
   /** . */
-  public static PropertyDescriptor<Integer> SMTP_PORT = new PropertyDescriptor<Integer>(Integer.class, "mail.smtp.port", 25, "The mail server port") {
+  public static final PropertyDescriptor<Integer> SMTP_PORT = new PropertyDescriptor<Integer>(Integer.class, "mail.smtp.port", 25, "The mail server port") {
     @Override
     protected Integer doParse(String s) throws Exception {
       return Integer.parseInt(s);
@@ -65,7 +65,7 @@ public class MailPlugin extends CRaSHPlugin<MailPlugin> {
   };
 
   /** . */
-  public static PropertyDescriptor<SmtpSecure> SMTP_SECURE = new PropertyDescriptor<SmtpSecure>(SmtpSecure.class, "mail.smtp.secure", SmtpSecure.NONE, "The mail server port") {
+  public static final PropertyDescriptor<SmtpSecure> SMTP_SECURE = new PropertyDescriptor<SmtpSecure>(SmtpSecure.class, "mail.smtp.secure", SmtpSecure.NONE, "The mail server port") {
     @Override
     protected SmtpSecure doParse(String s) throws Exception {
       return SmtpSecure.valueOf(s.toUpperCase());
@@ -73,7 +73,7 @@ public class MailPlugin extends CRaSHPlugin<MailPlugin> {
   };
 
   /** . */
-  public static PropertyDescriptor<String> SMTP_USERNAME = new PropertyDescriptor<String>(String.class, "mail.smtp.username", null, "The mail server user name") {
+  public static final PropertyDescriptor<String> SMTP_USERNAME = new PropertyDescriptor<String>(String.class, "mail.smtp.username", null, "The mail server user name") {
     @Override
     protected String doParse(String s) throws Exception {
       return s;
@@ -81,7 +81,7 @@ public class MailPlugin extends CRaSHPlugin<MailPlugin> {
   };
 
   /** . */
-  public static PropertyDescriptor<String> SMTP_PASSWORD = new PropertyDescriptor<String>(String.class, "mail.smtp.password", null, "The mail server passord", true) {
+  public static final PropertyDescriptor<String> SMTP_PASSWORD = new PropertyDescriptor<String>(String.class, "mail.smtp.password", null, "The mail server passord", true) {
     @Override
     protected String doParse(String s) throws Exception {
       return s;
@@ -89,7 +89,7 @@ public class MailPlugin extends CRaSHPlugin<MailPlugin> {
   };
 
   /** . */
-  public static PropertyDescriptor<String> SMTP_FROM = new PropertyDescriptor<String>(String.class, "mail.smtp.from", null, "The mail sender address") {
+  public static final PropertyDescriptor<String> SMTP_FROM = new PropertyDescriptor<String>(String.class, "mail.smtp.from", null, "The mail sender address") {
     @Override
     protected String doParse(String s) throws Exception {
       return s;
@@ -97,7 +97,7 @@ public class MailPlugin extends CRaSHPlugin<MailPlugin> {
   };
 
   /** . */
-  public static PropertyDescriptor<Boolean> DEBUG = new PropertyDescriptor<Boolean>(Boolean.class, "mail.debug", false, "The mail smtp debug mode") {
+  public static final PropertyDescriptor<Boolean> DEBUG = new PropertyDescriptor<Boolean>(Boolean.class, "mail.debug", false, "The mail smtp debug mode") {
     @Override
     protected Boolean doParse(String s) throws Exception {
       return Boolean.parseBoolean(s);

--- a/shell/src/main/java/org/crsh/text/Renderer.java
+++ b/shell/src/main/java/org/crsh/text/Renderer.java
@@ -49,7 +49,7 @@ public abstract class Renderer<E> {
     renderables = tmp.toArray(new Renderer<?>[tmp.size()]);
   }
 
-  public static Renderer<Object> ANY = new Renderer<Object>() {
+  public static final Renderer<Object> ANY = new Renderer<Object>() {
     @Override
     public Class<Object> getType() {
       return Object.class;

--- a/shell/src/main/java/org/crsh/util/Utils.java
+++ b/shell/src/main/java/org/crsh/util/Utils.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.NoSuchElementException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -90,13 +91,13 @@ public class Utils {
     return map;
   }
 
-  public static <K, V> HashMap<K, V> map(K key, V value) {
+  public static <K, V> Map<K, V> map(K key, V value) {
     HashMap<K, V> map = new HashMap<K, V>();
     map.put(key, value);
     return map;
   }
 
-  public static <E> HashSet<E> set(E... elements) {
+  public static <E> Set<E> set(E... elements) {
     HashSet<E> set = new HashSet<E>(elements.length);
     Collections.addAll(set, elements);
     return set;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1444 public static fields should be constant
squid:S1319 Declarations should use collection interfaces instead of specific implementation classes

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1444
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1319

Please let me know if you have any questions.

Zeeshan
