### PR TITLE
Objects should be compared with "equals()"

### DIFF
--- a/cli/src/main/java/org/crsh/cli/completers/EnumCompleter.java
+++ b/cli/src/main/java/org/crsh/cli/completers/EnumCompleter.java
@@ -41,7 +41,7 @@ public class EnumCompleter implements Completer {
   }
 
   public Completion complete(ParameterDescriptor parameter, String prefix) throws Exception {
-    if (parameter.getType() == ValueType.ENUM) {
+    if (ValueType.ENUM.equals(parameter.getType())) {
       Completion.Builder builder = null;
       Class<?> vt = parameter.getDeclaredType();
       Method valuesM = vt.getDeclaredMethod("values");

--- a/cli/src/main/java/org/crsh/cli/completers/ObjectNameCompleter.java
+++ b/cli/src/main/java/org/crsh/cli/completers/ObjectNameCompleter.java
@@ -47,7 +47,7 @@ public class ObjectNameCompleter implements Completer {
 
   @Override
   public Completion complete(ParameterDescriptor parameter, String prefix) throws Exception {
-    if (parameter.getType() == ValueType.OBJECT_NAME) {
+    if (ValueType.OBJECT_NAME.equals(parameter.getType())) {
       MBeanServer server = ManagementFactory.getPlatformMBeanServer();
       int colon = prefix.indexOf(':');
       if (colon == -1) {

--- a/cli/src/main/java/org/crsh/cli/descriptor/OptionDescriptor.java
+++ b/cli/src/main/java/org/crsh/cli/descriptor/OptionDescriptor.java
@@ -101,7 +101,7 @@ public class OptionDescriptor extends ParameterDescriptor {
       annotation);
 
     //
-    if (getMultiplicity() == Multiplicity.MULTI && getType() == ValueType.BOOLEAN) {
+    if (Multiplicity.MULTI.equals(getMultiplicity()) && ValueType.BOOLEAN.equals(getType())) {
       throw new IllegalParameterException();
     }
 
@@ -126,7 +126,7 @@ public class OptionDescriptor extends ParameterDescriptor {
     }
 
     //
-    if (getType() == ValueType.BOOLEAN) {
+    if (ValueType.BOOLEAN.equals(getType())) {
       arity = 0;
     } else {
       arity = 1;

--- a/cli/src/main/java/org/crsh/cli/impl/invocation/InvocationMatch.java
+++ b/cli/src/main/java/org/crsh/cli/impl/invocation/InvocationMatch.java
@@ -83,7 +83,7 @@ public final class InvocationMatch<T> {
       return (ParameterMatch<D>)options.get(parameter);
     } else {
       for (ArgumentMatch argumentMatch : arguments) {
-        if (argumentMatch.getParameter()  == parameter) {
+        if (argumentMatch.getParameter().equals(parameter)) {
           return (ParameterMatch<D>)argumentMatch;
         }
       }

--- a/cli/src/main/java/org/crsh/cli/impl/invocation/InvocationMatcher.java
+++ b/cli/src/main/java/org/crsh/cli/impl/invocation/InvocationMatcher.java
@@ -152,7 +152,7 @@ public class InvocationMatcher<T> {
               argumentEvent.getTo(),
               bilto(argumentEvent.getValues())
           );
-          if (argumentEvent.getCommand() == current.getDescriptor()) {
+          if (argumentEvent.getCommand().equals(current.getDescriptor())) {
             current.argument(match);
           } else {
             throw new AssertionError();

--- a/connectors/telnet/src/main/java/org/crsh/telnet/term/TelnetIO.java
+++ b/connectors/telnet/src/main/java/org/crsh/telnet/term/TelnetIO.java
@@ -141,7 +141,7 @@ public class TelnetIO implements TermIO {
   }
 
   public void write(Style style) throws IOException {
-    if (style == Style.reset) {
+    if (Style.reset.equals(style)) {
       termIO.resetAttributes();
       termIO.write("");
     } else {

--- a/connectors/web/src/main/java/org/crsh/web/servlet/WSProcessContext.java
+++ b/connectors/web/src/main/java/org/crsh/web/servlet/WSProcessContext.java
@@ -147,10 +147,10 @@ public class WSProcessContext implements ShellProcessContext, KeyHandler {
       } else {
         Style.Composite composite = (Style.Composite)style;
         buffer.append("[[");
-        if (composite.getUnderline() == Boolean.TRUE) {
+        if (Boolean.TRUE.equals(composite.getUnderline())) {
           buffer.append('u');
         }
-        if (composite.getBold() == Boolean.TRUE) {
+        if (Boolean.TRUE.equals(composite.getBold())) {
           buffer.append('b');
         }
         buffer.append(';');

--- a/shell/src/main/java/org/crsh/console/Editor.java
+++ b/shell/src/main/java/org/crsh/console/Editor.java
@@ -115,7 +115,7 @@ class Editor extends Plugin {
    * @return the current bound
    */
   int getCursorBound() {
-    if (console.getMode() == Mode.EMACS) {
+    if (Mode.EMACS.equals(console.getMode())) {
       return buffer.getSize();
     } else {
       return Math.max(0, buffer.getSize() - 1);

--- a/shell/src/main/java/org/crsh/console/EditorAction.java
+++ b/shell/src/main/java/org/crsh/console/EditorAction.java
@@ -200,7 +200,7 @@ class EditorAction {
         editor.console.status = Console.CLOSING;
         return null;
       } else {
-        if (editor.console.getMode() == Mode.EMACS) {
+        if (Mode.EMACS.equals(editor.console.getMode())) {
           return EditorAction.DELETE_PREV_CHAR.execute(editor, buffer, sequence, true);
         } else {
           return EditorAction.ENTER.execute(editor, buffer, sequence, true);
@@ -687,7 +687,7 @@ class EditorAction {
               buffer.moveRight(b); // Should be assertion
               buffer.moveRight(a); // Should be assertion
               // A bit not great : need to find a better way to do that...
-              if (editor.console.getMode() == Mode.VI_MOVE && buffer.getCursor() > editor.getCursorBound()) {
+              if (Mode.VI_MOVE.equals(editor.console.getMode()) && buffer.getCursor() > editor.getCursorBound()) {
                 buffer.moveLeft();
               }
             }
@@ -742,7 +742,7 @@ class EditorAction {
       editor.historyBuffer = null;
       String line = buffer.getLine();
       editor.lineParser.append(line);
-      if (editor.console.getMode() == Mode.VI_MOVE) {
+      if (Mode.VI_MOVE.equals(editor.console.getMode())) {
         editor.console.setMode(Mode.VI_INSERT);
       }
       if (editor.lineParser.crlf()) {

--- a/shell/src/main/java/org/crsh/lang/impl/groovy/closure/PipeLineClosure.java
+++ b/shell/src/main/java/org/crsh/lang/impl/groovy/closure/PipeLineClosure.java
@@ -192,7 +192,7 @@ public class PipeLineClosure extends Closure {
         else {
           boolean use = true;
           for (Object value : closureOptions.values()) {
-            if (value == ret) {
+            if (value.equals(ret)) {
               use = false;
               break;
             }

--- a/shell/src/main/java/org/crsh/lang/impl/java/JavaFileManagerImpl.java
+++ b/shell/src/main/java/org/crsh/lang/impl/java/JavaFileManagerImpl.java
@@ -52,7 +52,7 @@ class JavaFileManagerImpl extends ForwardingJavaFileManager<StandardJavaFileMana
 
   @Override
   public boolean hasLocation(Location location) {
-    return location == StandardLocation.CLASS_PATH || location == StandardLocation.PLATFORM_CLASS_PATH;
+    return StandardLocation.CLASS_PATH.equals(location) || StandardLocation.PLATFORM_CLASS_PATH.equals(location);
   }
 
   @Override
@@ -67,10 +67,10 @@ class JavaFileManagerImpl extends ForwardingJavaFileManager<StandardJavaFileMana
 
   @Override
   public Iterable<JavaFileObject> list(Location location, String packageName, Set<JavaFileObject.Kind> kinds, boolean recurse) throws IOException {
-    if (location == StandardLocation.PLATFORM_CLASS_PATH) {
+    if (StandardLocation.PLATFORM_CLASS_PATH.equals(location)) {
       return fileManager.list(location, packageName, kinds, recurse);
     }
-    else if (location == StandardLocation.CLASS_PATH && kinds.contains(JavaFileObject.Kind.CLASS)) {
+    else if (StandardLocation.CLASS_PATH.equals(location) && kinds.contains(JavaFileObject.Kind.CLASS)) {
       if (packageName.startsWith("java")) {
         return fileManager.list(location, packageName, kinds, recurse);
       }
@@ -91,7 +91,7 @@ class JavaFileManagerImpl extends ForwardingJavaFileManager<StandardJavaFileMana
   @Override
   public JavaFileObject getJavaFileForOutput(Location location, String className, JavaFileObject.Kind kind, FileObject sibling) throws IOException {
 
-    if (location != StandardLocation.CLASS_OUTPUT) {
+    if (!StandardLocation.CLASS_OUTPUT.equals(location)) {
       throw new IOException("Location " + location + " not supported");
     }
     if (kind != JavaFileObject.Kind.CLASS) {

--- a/shell/src/main/java/org/crsh/shell/impl/remoting/ClientProcessContext.java
+++ b/shell/src/main/java/org/crsh/shell/impl/remoting/ClientProcessContext.java
@@ -207,7 +207,7 @@ class ClientProcessContext implements ShellProcessContext {
   public synchronized void end(ShellResponse response) {
 
     // It may have been cancelled concurrently
-    if (client.current == this) {
+    if (client.current.equals(this)) {
 
       // Flush what we have in buffer first
       flush();

--- a/shell/src/main/java/org/crsh/shell/impl/remoting/ServerAutomaton.java
+++ b/shell/src/main/java/org/crsh/shell/impl/remoting/ServerAutomaton.java
@@ -185,7 +185,7 @@ public class ServerAutomaton implements Shell {
   }
 
   void cancel(ServerProcess process) throws IllegalStateException {
-    if (process == this.process) {
+    if (process.equals(this.process)) {
       this.process = null;
       try {
         out.writeObject(new ClientMessage.Cancel());

--- a/shell/src/main/java/org/crsh/text/Style.java
+++ b/shell/src/main/java/org/crsh/text/Style.java
@@ -171,7 +171,7 @@ public abstract class Style implements Serializable {
       if (s == null) {
         throw new NullPointerException();
       }
-      if (s == reset) {
+      if (s.equals(reset)) {
         return reset;
       } else {
         Style.Composite that = (Composite)s;

--- a/shell/src/main/java/org/crsh/text/renderers/LogRecordRenderer.java
+++ b/shell/src/main/java/org/crsh/text/renderers/LogRecordRenderer.java
@@ -58,11 +58,11 @@ public class LogRecordRenderer extends Renderer<LogRecord> {
             LogRecord record = stream.next();
             String line = formatter.format(record);
             Color color;
-            if (record.getLevel() == Level.SEVERE) {
+            if (Level.SEVERE.equals(record.getLevel())) {
               color = Color.red;
-            } else if (record.getLevel() == Level.WARNING) {
+            } else if (Level.WARNING.equals(record.getLevel())) {
               color = Color.yellow;
-            } else if (record.getLevel() == Level.INFO) {
+            } else if (Level.INFO.equals(record.getLevel())) {
               color = Color.green;
             } else {
               color = Color.blue;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1698 Objects should be compared with "equals()"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1698
Please let me know if you have any questions.

Zeeshan
