### PR TITLE
Classes and methods that rely on the default system encoding should not be used

### DIFF
--- a/connectors/ssh/src/main/java/org/crsh/auth/FilePublicKeyProvider.java
+++ b/connectors/ssh/src/main/java/org/crsh/auth/FilePublicKeyProvider.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.security.KeyPair;
 import java.security.PublicKey;
 import java.util.ArrayList;
@@ -59,7 +60,7 @@ class FilePublicKeyProvider extends AbstractKeyPairProvider {
     List<KeyPair> keys = new ArrayList<KeyPair>();
     for (String file : files) {
       try {
-          Object o = KeyPairUtils.readKey(new InputStreamReader(new FileInputStream(file)));
+          Object o = KeyPairUtils.readKey(new InputStreamReader(new FileInputStream(file), Charset.forName("UTF-8")));
           if (o instanceof KeyPair) {
             keys.add(new KeyPair(((KeyPair)o).getPublic(), null));
           } else if (o instanceof PublicKey) {

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/URLKeyPairProvider.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/URLKeyPairProvider.java
@@ -27,6 +27,7 @@ import org.crsh.vfs.Resource;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.security.KeyPair;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +54,7 @@ public class URLKeyPairProvider extends AbstractKeyPairProvider {
     List<KeyPair> keys = new ArrayList<KeyPair>();
     if (key != null) {
       try {
-          Object o = KeyPairUtils.readKey(new InputStreamReader(new ByteArrayInputStream(key.getContent())));
+          Object o = KeyPairUtils.readKey(new InputStreamReader(new ByteArrayInputStream(key.getContent()), Charset.forName("UTF-8")));
           if (o instanceof KeyPair) {
             keys.add((KeyPair) o);
           } else if(o instanceof PEMKeyPair) {

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/inline/SSHInlineCommand.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/inline/SSHInlineCommand.java
@@ -12,6 +12,7 @@ import org.crsh.ssh.term.SSHLifeCycle;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.security.Principal;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -58,8 +59,17 @@ public class SSHInlineCommand extends AbstractCommand implements Runnable {
   public void run() {
 
     // get principal
-    PrintStream err = new PrintStream(this.err);
-    PrintStream out = new PrintStream(this.out);
+    PrintStream err = null;
+    PrintStream out = null;
+    try {
+      err = new PrintStream(this.err, false, "UTF-8");
+      out = new PrintStream(this.out, false, "UTF-8");
+    }
+    catch (UnsupportedEncodingException uee) {
+      log.log(Level.INFO, "UTF-8 character encoding not supported " + uee);
+      err = new PrintStream(this.err);
+      out = new PrintStream(this.out);
+    }
     final String userName = session.getAttribute(SSHLifeCycle.USERNAME);
     Principal user = new Principal() {
       public String getName() {

--- a/doc/reference/src/main/java/org/crsh/doc/Generator.java
+++ b/doc/reference/src/main/java/org/crsh/doc/Generator.java
@@ -73,7 +73,7 @@ public class Generator {
     }
     if (buffer.length() > 0) {
       File f = new File(root, "reference.asciidoc");
-      PrintWriter pw = new PrintWriter(f);
+      PrintWriter pw = new PrintWriter(f, "UTF-8");
       try {
         System.out.println("Generating asciidoc file " + f.getCanonicalPath());
         pw.print(buffer);

--- a/shell/src/main/java/org/crsh/lang/impl/java/JavaCompiler.java
+++ b/shell/src/main/java/org/crsh/lang/impl/java/JavaCompiler.java
@@ -27,6 +27,7 @@ import org.crsh.shell.impl.command.spi.Command;
 import org.crsh.lang.spi.CommandResolution;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -53,7 +54,7 @@ public class JavaCompiler implements org.crsh.lang.spi.Compiler {
   }
 
   public CommandResolution compileCommand(String name, byte[] source) throws CommandException, NullPointerException {
-    String script = new String(source);
+    String script = new String(source, Charset.forName("UTF-8"));
     List<JavaClassFileObject> classFiles;
     try {
       classFiles = compiler.compile(name, script);

--- a/shell/src/main/java/org/crsh/lang/impl/script/ScriptCompiler.java
+++ b/shell/src/main/java/org/crsh/lang/impl/script/ScriptCompiler.java
@@ -41,6 +41,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Map;
@@ -163,7 +164,7 @@ public class ScriptCompiler implements Compiler {
                   public void close() throws IOException, CommandException {
 
                     // Execute sequentially the script
-                    BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(source)));
+                    BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(source), Charset.forName("UTF-8")));
 
                     // A bit nasty but well it's ok
                     ShellSession session = (ShellSession)consumer.getSession();

--- a/shell/src/main/java/org/crsh/plugin/ResourceManager.java
+++ b/shell/src/main/java/org/crsh/plugin/ResourceManager.java
@@ -26,6 +26,7 @@ import org.crsh.vfs.Resource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -165,7 +166,7 @@ public class ResourceManager {
   }
 
   /** . */
-  private static final byte[] SEPARATOR = System.getProperty("line.separator").getBytes();
+  private static final byte[] SEPARATOR = System.getProperty("line.separator").getBytes(Charset.forName("UTF-8"));
 
   public static Resource loadConf(File file) throws IOException {
     // Special handling for property files

--- a/shell/src/main/java/org/crsh/vfs/spi/ram/RAMURLConnection.java
+++ b/shell/src/main/java/org/crsh/vfs/spi/ram/RAMURLConnection.java
@@ -43,6 +43,6 @@ public class RAMURLConnection extends URLConnection {
 
   @Override
   public InputStream getInputStream() throws IOException{
-    return new ByteArrayInputStream(file.getBytes());
+    return new ByteArrayInputStream(file.getBytes("UTF-8"));
   }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

Zeeshan
