### PR TITLE
Add missing default statement to switch

### DIFF
--- a/cli/src/main/java/org/crsh/cli/impl/Delimiter.java
+++ b/cli/src/main/java/org/crsh/cli/impl/Delimiter.java
@@ -35,6 +35,8 @@ public enum Delimiter {
           case '\'':
           case '\\':
             appendable.append('\\');
+          default:
+            break;
         }
         appendable.append(c);
       }
@@ -51,6 +53,8 @@ public enum Delimiter {
             case '\'':
             case '\\':
               appendable.append('\\');
+            default:
+              break;
           }
           appendable.append(c);
         }
@@ -68,6 +72,8 @@ public enum Delimiter {
             case '"':
             case '\\':
               appendable.append('\\');
+            default:
+              break;
           }
           appendable.append(c);
         }

--- a/cli/src/main/java/org/crsh/cli/impl/line/LineParser.java
+++ b/cli/src/main/java/org/crsh/cli/impl/line/LineParser.java
@@ -160,6 +160,8 @@ public final class LineParser {
             index += 2;
           }
           break;
+        default:
+          break;
       }
       escaped = false;
     }

--- a/shell/src/main/java/org/crsh/shell/impl/remoting/ServerProcess.java
+++ b/shell/src/main/java/org/crsh/shell/impl/remoting/ServerProcess.java
@@ -65,6 +65,8 @@ public class ServerProcess implements ShellProcess {
       case 1:
         server.cancel(this);
         break;
+      default:
+        break;
     }
   }
 }

--- a/shell/src/main/java/org/crsh/util/Utils.java
+++ b/shell/src/main/java/org/crsh/util/Utils.java
@@ -752,6 +752,8 @@ public class Utils {
             status = SCANNING;
           }
           break;
+        default:
+          break;
       }
     }
     switch (status) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of FindBugs rule SF_SWITCH_NO_DEFAULT - “ Switch statement found where default case is missing ”. You can find more information about the issue here: http://findbugs.sourceforge.net/bugDescriptions.html#SF_SWITCH_NO_DEFAULT
Please let me know if you have any questions.
Ayman Abdelghany.
