### PR TITLE
Override hashcode whenever overriding equals()

### DIFF
--- a/cli/src/main/java/org/crsh/cli/descriptor/Description.java
+++ b/cli/src/main/java/org/crsh/cli/descriptor/Description.java
@@ -134,4 +134,11 @@ public final class Description {
       return false;
     }
   }
+
+  @Override
+  public int hashCode() {
+    int result = usage != null ? usage.hashCode() : 0;
+    result = 31 * result + (man != null ? man.hashCode() : 0);
+    return result;
+  }
 }

--- a/cli/src/main/java/org/crsh/cli/impl/completion/CompletionMatch.java
+++ b/cli/src/main/java/org/crsh/cli/impl/completion/CompletionMatch.java
@@ -66,6 +66,13 @@ public final class CompletionMatch implements Serializable {
   }
 
   @Override
+  public int hashCode() {
+    int result = delimiter != null ? delimiter.hashCode() : 0;
+    result = 31 * result + (value != null ? value.hashCode() : 0);
+    return result;
+  }
+
+  @Override
   public String toString() {
     return "CommandCompletion[delimiter=" + delimiter + ",value=" + value + "]";
   }

--- a/cli/src/main/java/org/crsh/cli/impl/tokenizer/Token.java
+++ b/cli/src/main/java/org/crsh/cli/impl/tokenizer/Token.java
@@ -39,6 +39,8 @@ public abstract class Token {
       }
       return false;
     }
+    
+    
 
     @Override
     public String toString() {
@@ -126,6 +128,13 @@ public abstract class Token {
     }
 
     @Override
+    public int hashCode() {
+      int result = super.hashCode();
+      result = 31 * result + (value != null ? value.hashCode() : 0);
+      return result;
+    }
+
+    @Override
     public String toString() {
       return getClass().getSimpleName() + "[index=" + index + ",raw=" + raw + ",value=" + value + "]";
     }
@@ -188,5 +197,12 @@ public abstract class Token {
       return index == that.index && raw.equals(that.raw);
     }
     return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = index;
+    result = 31 * result + (raw != null ? raw.hashCode() : 0);
+    return result;
   }
 }

--- a/shell/src/main/java/org/crsh/console/Mode.java
+++ b/shell/src/main/java/org/crsh/console/Mode.java
@@ -464,6 +464,11 @@ public abstract class Mode extends EditorAction {
     }
 
     @Override
+    public int hashCode() {
+      return count;
+    }
+
+    @Override
     public String toString() {
       return "Mode.ChangeChat[count=" + count + "]";
     }
@@ -508,6 +513,13 @@ public abstract class Mode extends EditorAction {
       } else {
         return false;
       }
+    }
+
+    @Override
+    public int hashCode() {
+      int result = count;
+      result = 31 * result + (to != null ? to.hashCode() : 0);
+      return result;
     }
 
     @Override

--- a/shell/src/main/java/org/crsh/plugin/PropertyDescriptor.java
+++ b/shell/src/main/java/org/crsh/plugin/PropertyDescriptor.java
@@ -206,6 +206,16 @@ public abstract class PropertyDescriptor<T> {
     }
   }
 
+  @Override
+  public int hashCode() {
+    int result = type != null ? type.hashCode() : 0;
+    result = 31 * result + (name != null ? name.hashCode() : 0);
+    result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
+    result = 31 * result + (description != null ? description.hashCode() : 0);
+    result = 31 * result + (secret ? 1 : 0);
+    return result;
+  }
+
   /**
    * Parse a string representation of a value and returns the correspondig property value.
    *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of FindBugs rule HE_EQUALS_USE_HASHCODE - “ Class defines equals() and uses Object.hashCode() ”. You can find more information about the issue here: http://findbugs.sourceforge.net/bugDescriptions.html#HE_EQUALS_USE_HASHCODE
Please let me know if you have any questions.
Ayman Abdelghany.
