### PR TITLE
Fix to enable support of Spring boot 1.4 jar layout.

### DIFF
--- a/shell/src/main/java/org/crsh/util/ZipIterator.java
+++ b/shell/src/main/java/org/crsh/util/ZipIterator.java
@@ -36,7 +36,7 @@ import java.util.zip.ZipInputStream;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public abstract class ZipIterator implements Closeable {
 
-  public static ZipIterator create(URL url) throws IOException, URISyntaxException {
+  public static ZipIterator create(URL url) throws IOException {
     if (url.getProtocol().equals("file")) {
       return create(Utils.toFile(url));
     } else if (url.getProtocol().equals("jar")) {
@@ -48,7 +48,7 @@ public abstract class ZipIterator implements Closeable {
       try {
         while (container.hasNext()) {
           ZipEntry entry = container.next();
-          if (entry.getName().equals(path)) {
+          if (entry.getName().equals(path) || entry.getName().equals(path + "/")) {
             InputStreamFactory resolved = container.getStreamFactory();
             final InputStream nested = resolved.open();
             InputStream filter = new InputStream() {
@@ -113,24 +113,24 @@ public abstract class ZipIterator implements Closeable {
     }
   }
 
-  static ZipIterator create(File file) throws IOException {
+  public static ZipIterator create(File file) throws IOException {
     // The fast way (but that requires a File object)
     final ZipFile jarFile = new ZipFile(file);
     final Enumeration<? extends ZipEntry> en = jarFile.entries();en.hasMoreElements();
     return new ZipIterator() {
       ZipEntry next;
       @Override
-      public boolean hasNext() throws IOException {
+      public boolean hasNext() {
         return en.hasMoreElements();
       }
       @Override
-      public ZipEntry next() throws IOException {
+      public ZipEntry next() {
         return next = en.nextElement();
       }
-      public void close() throws IOException {
+      public void close() {
       }
       @Override
-      public InputStreamFactory getStreamFactory() throws IOException {
+      public InputStreamFactory getStreamFactory() {
         final ZipEntry capture = next;
         return new InputStreamFactory() {
           public InputStream open() throws IOException {
@@ -141,7 +141,7 @@ public abstract class ZipIterator implements Closeable {
     };
   }
 
-  static ZipIterator create(InputStream in) throws IOException {
+  static ZipIterator create(InputStream in) {
     final byte[] tmp = new byte[512];
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     final ZipInputStream zip = new ZipInputStream(in);


### PR DESCRIPTION
Since Spring-boot 1.4 the layout changed, project classes are now located in BOOT-INF/classes. e.g. :

        0  11-23-2017 12:07   META-INF/
      437  11-23-2017 12:07   META-INF/MANIFEST.MF
        0  11-23-2017 12:07   BOOT-INF/
        0  11-23-2017 12:07   BOOT-INF/classes/
        0  11-22-2017 18:53   BOOT-INF/classes/**.class
        0  11-22-2017 18:53   BOOT-INF/classes/commands/
     4350  11-22-2017 18:53   BOOT-INF/classes/commands/migration.java
      563  11-22-2017 18:53   BOOT-INF/classes/application.yml
        0  11-23-2017 12:07   BOOT-INF/lib/
    40117  11-20-2017 10:52   BOOT-INF/lib/*.jar
        0  11-23-2017 12:07   org/
        0  11-23-2017 12:07   org/springframework/
        0  11-23-2017 12:07   org/springframework/boot/
        0  11-23-2017 12:07   org/springframework/boot/**.class

Also dirty fix to allow folders (ending by '/') when looking inside a jar.

Related to https://github.com/spring-projects/spring-boot/issues/7471 and https://github.com/spring-projects/spring-boot/issues/6384